### PR TITLE
Basic build of Bubblewrap with Meson.

### DIFF
--- a/config.h.meson
+++ b/config.h.meson
@@ -1,0 +1,98 @@
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#mesondefine HAVE_INTTYPES_H
+
+/* Define to 1 if you have the <memory.h> header file. */
+#mesondefine HAVE_MEMORY_H
+
+/* Define if SELinux is available */
+#mesondefine HAVE_SELINUX
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#mesondefine HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#mesondefine HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#mesondefine HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#mesondefine HAVE_STRING_H
+
+/* Define to 1 if you have the <sys/capability.h> header file. */
+#mesondefine HAVE_SYS_CAPABILITY_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#mesondefine HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#mesondefine HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#mesondefine HAVE_UNISTD_H
+
+/* Define to the address where bug reports for this package should be sent. */
+#mesondefine PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#mesondefine PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#mesondefine PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#mesondefine PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#mesondefine PACKAGE_URL
+
+/* Define to the version of this package. */
+#mesondefine PACKAGE_VERSION
+
+/* Define to 1 if you have the ANSI C header files. */
+#mesondefine STDC_HEADERS
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# undef _ALL_SOURCE
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# undef _GNU_SOURCE
+#endif
+/* Enable threading extensions on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# undef _POSIX_PTHREAD_SEMANTICS
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# undef _TANDEM_SOURCE
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# undef __EXTENSIONS__
+#endif
+
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#mesondefine _FILE_OFFSET_BITS
+
+/* Define for large files, on AIX-style hosts. */
+#mesondefine _LARGE_FILES
+
+/* Define to 1 if on MINIX. */
+#mesondefine _MINIX
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+#mesondefine _POSIX_1_SOURCE
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+#mesondefine _POSIX_SOURCE

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,53 @@
+project('bubblewrap', 'c', version : '0.1.5')
+
+cc = meson.get_compiler('c')
+
+assert(cc.has_header('sys/capability.h'), 'Capability header missing.')
+selinux_dep = dependency('libselinux', version : '>=2.1.9', required : false)
+
+add_project_arguments('-D_GNU_SOURCE', language : 'c')
+
+cdata = configuration_data()
+
+cdata.set_quoted('PACKAGE_STRING', 'bubblewrap')
+if selinux_dep.found()
+  cdata.set('HAVE_SELINUX', 1)
+endif
+configure_file(input : 'config.h.meson',
+  output : 'config.h',
+  configuration : cdata)
+
+bwrap_sources = [
+  'bubblewrap.c',
+  'bind-mount.c',
+  'network.c',
+  'utils.c',
+]
+
+executable('bwrap', bwrap_sources, install : true, dependencies : selinux_dep)
+
+xsltproc = find_program('xsltproc', required : false)
+
+if xsltproc.found()
+  custom_target('manpage',
+    output : 'bwrap.1',
+    input : 'bwrap.xml',
+    command : [xsltproc,
+      '-o', '@OUTPUT@',
+      '--nonet',
+      '--stringparam', 'man.output.quietly', '1',
+      '--stringparam', 'funcsynopsis.style', 'ansi',
+      '--stringparam', 'man.th.extra1.suppress', '1',
+      '--stringparam', 'man.authors.section.enabled', '0',
+      '--stringparam', 'man.copyright.section.enabled', '0',
+      'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl',
+      '@INPUT@',
+      ],
+    install : true,
+    install_dir : join_paths(get_option('mandir'), 'man1'),
+  )
+endif
+
+install_data('completions/bash/bwrap',
+  install_dir : join_paths(get_option('datadir'), 'bash-completion/completions')
+  )


### PR DESCRIPTION
Builds and installs Bubblewrap, the man page and the Bash completion file.

I could not properly comprehend how the setuid binary thing should work so I left that alone. FWICT it should just be a case of a custom install script or a custom target.

Selinux mode not tested because I don't have an selinux machine but It Should Work (TM).

The werror flags are not added. Maybe a better combination would be `warning_level=2` + werror? Anyway it is just a question of adding those to `add_project_arguments`.