### PR TITLE
Make --bind-data files have permissions 0666

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1167,6 +1167,9 @@ setup_newroot (bool unshare_pid,
             if (dest_fd == -1)
               die_with_error ("Can't create tmpfile for %s", op->dest);
 
+            if (fchmod (dest_fd, 0666) != 0)
+              die_with_error ("Can't chmod tmpfile for %s", op->dest);
+
             if (copy_file_data (op->fd, dest_fd) != 0)
               die_with_error ("Can't write data to file %s", op->dest);
 


### PR DESCRIPTION
When you use --bind-data or --ro-bind-data the file currently ends up with
permission 0600, as this is the mkstemp() default. All other codepaths in
bubblewrap creates 0666 files so that other users can read the files,
which is more common than top-secret files only readable by the user.

We fix this by fchmod()ing to 0666