### PR TITLE
Write out namespace ids to info-fd, json-status-fd

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2229,8 +2229,11 @@ main (int    argc,
       clone_flags |= CLONE_NEWCGROUP;
     }
   if (opt_unshare_cgroup_try)
-    if (!stat ("/proc/self/ns/cgroup", &sbuf))
-      clone_flags |= CLONE_NEWCGROUP;
+    {
+      opt_unshare_cgroup = !stat ("/proc/self/ns/cgroup", &sbuf);
+      if (opt_unshare_cgroup)
+        clone_flags |= CLONE_NEWCGROUP;
+    }
 
   child_wait_fd = eventfd (0, EFD_CLOEXEC);
   if (child_wait_fd == -1)


### PR DESCRIPTION
The idea is to write out the namespace "identifiers" for all newly created namespaces to the info-fd, json-status-fd. This could be useful e.g. in xdg-desktop-portal, where we need to [look up](https://github.com/flatpak/xdg-desktop-portal/blob/51d95ed18bba3824d5fb38e383bf913665b9e308/src/xdp-utils.c#L1613) the pid namespace id. For now I put them all with the `-namespace` suffix in the main dict object to make parsing easier:
```json
→ ./bwrap --ro-bind /usr /usr --symlink usr/lib64 /lib64 --proc /proc --dev /dev --unshare-pid --as-pid-1 --json-status-fd 1 --unshare-net bash
{ "child-pid": 14370, "user-namespace": 4026532874, "pid-namespace": 4026532876, "net-namespace": 4026532878 }
```
Other option would be to group them all in another dict, like:
```json
{ "child-pid": 14370, "namespaces": { "user": 4026532874, "pid": 4026532876, "net": 4026532878 } }
```
