### PR TITLE
retcode: fix return code with syncfd and no event_fd

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -496,17 +496,20 @@ do_init (int event_fd, pid_t initial_pid, struct sock_fprog *seccomp_prog)
       int status;
 
       child = wait (&status);
-      if (child == initial_pid && event_fd != -1)
+      if (child == initial_pid)
         {
-          uint64_t val;
-          int res UNUSED;
-
           initial_exit_status = propagate_exit_status (status);
 
-          val = initial_exit_status + 1;
-          res = write (event_fd, &val, 8);
-          /* Ignore res, if e.g. the parent died and closed event_fd
-             we don't want to error out here */
+          if(event_fd != -1)
+            {
+              uint64_t val;
+              int res UNUSED;
+
+              val = initial_exit_status + 1;
+              res = write (event_fd, &val, 8);
+              /* Ignore res, if e.g. the parent died and closed event_fd
+                 we don't want to error out here */
+            }
         }
 
       if (child == -1 && errno != EINTR)


### PR DESCRIPTION
I've encountered a situation where bubblewrap would always return 1 instead of subprocess retcode.

This is linked to the use of a *sync-fd* in a configuration where the *event_fd* is not created. To reproduce the issue (tested on 5e932e4 in setuid), one may run the following commands:

```bash
$ bwrap --bind / /  --sync-fd 2 true; echo "ret : $?"
ret : 1
/usr/local/bin/bwrap --bind / / true; echo "ret : $?"
ret : 0
```

In these two commands, the only difference is the *--sync-fd* that I've set to stderr for the sake of the example conciseness.

To my knowledge, the enclosed pull request solved this issue for me.

Thanks!

