### PR TITLE
Support for reusing namespaces

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -826,6 +826,10 @@ drop_privs (bool keep_requested_caps)
     die_with_error ("unable to drop root uid");
 
   drop_all_caps (keep_requested_caps);
+
+  /* We don't have any privs now, so mark us dumpable which makes /proc/self be owned by the user instead of root */
+  if (prctl (PR_SET_DUMPABLE, 1, 0, 0, 0) != 0)
+    die_with_error ("can't set dumpable");
 }
 
 static char *

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -805,7 +805,7 @@ static void
 switch_to_user_with_privs (void)
 {
   /* If we're in a new user namespace, we got back the bounding set, clear it again */
-  if (opt_unshare_user)
+  if (opt_unshare_user || opt_userns_fd != -1)
     drop_cap_bounding_set (FALSE);
 
   if (!is_privileged)

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -822,7 +822,7 @@ drop_privs (bool keep_requested_caps)
 {
   assert (!keep_requested_caps || !is_privileged);
   /* Drop root uid */
-  if (getuid () == 0 && setuid (opt_sandbox_uid) < 0)
+  if (geteuid () == 0 && setuid (opt_sandbox_uid) < 0)
     die_with_error ("unable to drop root uid");
 
   drop_all_caps (keep_requested_caps);

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -811,10 +811,10 @@ switch_to_user_with_privs (void)
   /* If we switched to a new user namespace it may allow other uids/gids, so switch to the target one */
   if (opt_userns_fd != -1)
     {
-      if (setuid (opt_sandbox_uid) < 0)
+      if (opt_sandbox_uid != real_uid && setuid (opt_sandbox_uid) < 0)
         die_with_error ("unable to switch to uid %d", opt_sandbox_uid);
 
-      if (setgid (opt_sandbox_gid) < 0)
+      if (opt_sandbox_gid != real_gid && setgid (opt_sandbox_gid) < 0)
         die_with_error ("unable to switch to gid %d", opt_sandbox_gid);
     }
 

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2429,7 +2429,7 @@ main (int    argc,
       die_with_error ("Joining specified user namespace failed");
     }
 
-  /* Sometimes we have uninteresting intermidate pids during the setup, set up code to pass the real pid down */
+  /* Sometimes we have uninteresting intermediate pids during the setup, set up code to pass the real pid down */
   if (opt_pidns_fd != -1)
     {
       /* Mark us as a subreaper, this way we can get exit status from grandchildren */

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -141,6 +141,11 @@
       <para>This is useful because sometimes bubblewrap itself creates nested user namespaces (to work around some kernel issues) and --userns2 can be used to enter these.</para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--pidns <arg choice="plain">FD</arg></option></term>
+      <listitem><para>Use an existing pid namespace instead of creating one. This is often used with --userns, because the pid namespace must be owned by the same user namespace that bwrap uses. </para>
+      <para>Note that this can be combined with --unshare-pid, and in that case it means that the sandbox will be in its own pid namespace, which is a child of the passed in one.</para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--uid <arg choice="plain">UID</arg></option></term>
       <listitem><para>Use a custom user id in the sandbox (requires <option>--unshare-user</option>)</para></listitem>
     </varlistentry>

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -131,6 +131,16 @@
       <listitem><para>Unshare all possible namespaces. Currently equivalent with: <option>--unshare-user-try</option> <option>--unshare-ipc</option> <option>--unshare-pid</option> <option>--unshare-net</option> <option>--unshare-uts</option> <option>--unshare-cgroup-try</option></para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--userns <arg choice="plain">FD</arg></option></term>
+      <listitem><para>Use an existing user namespace instead of creating a new one. The namespace must fulfil the permission requirements for setns(), which generally means that it must be a decendant of the currently active user namespace, owned by the same user. </para>
+      <para>This is incompatible with --unshare-user, and doesn't work in the setuid version of bubblewrap.</para></listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><option>--userns2 <arg choice="plain">FD</arg></option></term>
+      <listitem><para>After setting up the new namespace, switch into the specified namespace. For this to work the specified namespace must be a decendant of the user namespace used for the setup, so this is only useful in combination with --userns.</para>
+      <para>This is useful because sometimes bubblewrap itself creates nested user namespaces (to work around some kernel issues) and --userns2 can be used to enter these.</para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--uid <arg choice="plain">UID</arg></option></term>
       <listitem><para>Use a custom user id in the sandbox (requires <option>--unshare-user</option>)</para></listitem>
     </varlistentry>

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -75,6 +75,18 @@ _fatal_print_file() {
     fatal "$@"
 }
 
+_fatal_print_files() {
+    file1="$1"
+    shift
+    file2="$1"
+    shift
+    ls -al "$file1" >&2
+    sed -e 's/^/# /' < "$file1" >&2
+    ls -al "$file2" >&2
+    sed -e 's/^/# /' < "$file2" >&2
+    fatal "$@"
+}
+
 assert_not_has_file () {
     if test -f "$1"; then
         _fatal_print_file "$1" "File '$1' exists"
@@ -137,7 +149,7 @@ assert_file_empty() {
 
 assert_files_equal() {
     if ! cmp "$1" "$2"; then
-        _fatal_print_file "$1" "File '$1' and '$2' is not equal"
+        _fatal_print_files "$1" "$2" "File '$1' and '$2' is not equal"
     fi
 }
 

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -135,8 +135,18 @@ assert_file_empty() {
     fi
 }
 
+assert_files_equal() {
+    if ! cmp "$1" "$2"; then
+        _fatal_print_file "$1" "File '$1' and '$2' is not equal"
+    fi
+}
+
 # Use to skip all of these tests
 skip() {
     echo "1..0 # SKIP" "$@"
     exit 0
+}
+
+extract_child_pid() {
+    grep child-pid "$1" | sed "s/^.*: \([0-9]*\).*/\1/"
 }

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -80,7 +80,7 @@ if ! $RUN true; then
     skip Seems like bwrap is not working at all. Maybe setuid is not working
 fi
 
-echo "1..47"
+echo "1..48"
 
 # Test help
 ${BWRAP} --help > help.txt
@@ -339,5 +339,25 @@ if $RUN --bind "$(pwd)" /tmp/here test -d /tmp/newroot; then
     assert_not_reached "/tmp/newroot should not be visible"
 fi
 echo "ok - we can mount another directory inside /tmp"
+
+# These tests need user namespaces
+if test -n "${bwrap_is_suid:-}"; then
+    echo "ok - # SKIP no setuid support for --unshare-user"
+else
+    mkfifo donepipe
+
+    $RUN --info-fd 42 --unshare-user sh -c 'ls -l /proc/self/ns/user > sandbox-userns; cat < donepipe' 42>info.json &
+    while ! test -f sandbox-userns; do sleep 1; done
+    SANDBOX1PID=$(extract_child_pid info.json)
+
+    $RUN  --userns 11 ls -l /proc/self/ns/user > sandbox2-userns 11< /proc/$SANDBOX1PID/ns/user
+    echo foo > donepipe
+
+    assert_files_equal sandbox-userns sandbox2-userns
+
+    rm donepipe info.json sandbox-userns
+
+    echo "ok - Test --userns"
+fi
 
 echo "ok - End of test"

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -347,11 +347,11 @@ if test -n "${bwrap_is_suid:-}"; then
 else
     mkfifo donepipe
 
-    $RUN --info-fd 42 --unshare-user sh -c 'ls -l /proc/self/ns/user > sandbox-userns; cat < donepipe' 42>info.json &
+    $RUN --info-fd 42 --unshare-user sh -c 'readlink /proc/self/ns/user > sandbox-userns; cat < donepipe' 42>info.json &
     while ! test -f sandbox-userns; do sleep 1; done
     SANDBOX1PID=$(extract_child_pid info.json)
 
-    $RUN  --userns 11 ls -l /proc/self/ns/user > sandbox2-userns 11< /proc/$SANDBOX1PID/ns/user
+    $RUN  --userns 11 readlink /proc/self/ns/user > sandbox2-userns 11< /proc/$SANDBOX1PID/ns/user
     echo foo > donepipe
 
     assert_files_equal sandbox-userns sandbox2-userns
@@ -361,11 +361,11 @@ else
     echo "ok - Test --userns"
 
     mkfifo donepipe
-    $RUN --info-fd 42 --unshare-user --unshare-pid sh -c 'ls -l /proc/self/ns/pid > sandbox-pidns; cat < donepipe' 42>info.json &
+    $RUN --info-fd 42 --unshare-user --unshare-pid sh -c 'readlink /proc/self/ns/pid > sandbox-pidns; cat < donepipe' 42>info.json &
     while ! test -f sandbox-pidns; do sleep 1; done
     SANDBOX1PID=$(extract_child_pid info.json)
 
-    $RUN --userns 11 --pidns 12 ls -l /proc/self/ns/pid > sandbox2-pidns 11< /proc/$SANDBOX1PID/ns/user 12< /proc/$SANDBOX1PID/ns/pid
+    $RUN --userns 11 --pidns 12 readlink /proc/self/ns/pid > sandbox2-pidns 11< /proc/$SANDBOX1PID/ns/user 12< /proc/$SANDBOX1PID/ns/pid
     echo foo > donepipe
 
     assert_files_equal sandbox-pidns sandbox2-pidns

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -80,7 +80,7 @@ if ! $RUN true; then
     skip Seems like bwrap is not working at all. Maybe setuid is not working
 fi
 
-echo "1..46"
+echo "1..47"
 
 # Test help
 ${BWRAP} --help > help.txt

--- a/utils.c
+++ b/utils.c
@@ -80,6 +80,19 @@ die_oom (void)
   exit (1);
 }
 
+/* Fork, return in child, exiting the previous parent */
+void
+fork_intermediate_child (void)
+{
+  int pid = fork ();
+  if (pid == -1)
+    die_with_error ("Can't fork for --pidns");
+
+  /* Parent is an process not needed */
+  if (pid != 0)
+    exit (0);
+}
+
 void *
 xmalloc (size_t size)
 {

--- a/utils.h
+++ b/utils.h
@@ -54,6 +54,8 @@ void  die (const char *format,
 void  die_oom (void) __attribute__((__noreturn__));
 void  die_unless_label_valid (const char *label);
 
+void  fork_intermediate_child (void);
+
 void *xmalloc (size_t size);
 void *xcalloc (size_t size);
 void *xrealloc (void  *ptr,

--- a/utils.h
+++ b/utils.h
@@ -107,6 +107,9 @@ int   get_file_mode (const char *pathname);
 int   mkdir_with_parents (const char *pathname,
                           int         mode,
                           bool        create_last);
+void create_pid_socketpair (int sockets[2]);
+void send_pid_on_socket (int socket);
+int  read_pid_from_socket (int socket);
 
 /* syscall wrappers */
 int   raw_clone (unsigned long flags,


### PR DESCRIPTION
The end goal for this work is to run chrome in a flatpak, using the self-sandboxing portal. For this we want to be able to have the portal spawn a new sandbox with limited pid & fs & network access, yet have the requesting pid (the main chrome process) see these new pids.

To do this we add a new --userns feature to bwrap where it can reuse and existing user namespace for getting capabilities and then --pidns that allows bwrap to reuse an existing pid namespace. We'll use both --pidns and --unshare-pid which means that first enter the old pid namespace, but then create a new pid namespace as a child of that.

Fundamentally this should be workable with the setuid mode, at least when user namespaces are supported, however for technical reasons I was not able to do that (see commit comments) so I just disabled the new feature in the setuid case.

This PR also fixes some issues I found during development.