### PR TITLE
args: Add and use a helper to parse file descriptors

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1432,6 +1432,19 @@ print_version_and_exit (void)
   exit (0);
 }
 
+static int
+parse_fd_arg (const char *arg)
+{
+  char *endptr;
+  int the_fd;
+
+  the_fd = strtol (arg, &endptr, 10);
+  if (arg[0] == 0 || endptr[0] != 0 || the_fd < 0)
+    die ("Invalid fd: %s", arg);
+
+  return the_fd;
+}
+
 static void
 parse_args_recurse (int          *argcp,
                     const char ***argvp,
@@ -1471,7 +1484,6 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--args") == 0)
         {
           int the_fd;
-          char *endptr;
           const char *p, *data_end;
           size_t data_len;
           cleanup_free const char **data_argv = NULL;
@@ -1485,9 +1497,7 @@ parse_args_recurse (int          *argcp,
           if (argc < 2)
             die ("--args takes an argument");
 
-          the_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || the_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          the_fd = parse_fd_arg (argv[1]);
 
           /* opt_args_data is essentially a recursive argv array, which we must
            * keep allocated until exit time, since its argv entries get used
@@ -1727,14 +1737,11 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--file") == 0)
         {
           int file_fd;
-          char *endptr;
 
           if (argc < 3)
             die ("--file takes two arguments");
 
-          file_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || file_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          file_fd = parse_fd_arg (argv[1]);
 
           op = setup_op_new (SETUP_MAKE_FILE);
           op->fd = file_fd;
@@ -1746,14 +1753,11 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--bind-data") == 0)
         {
           int file_fd;
-          char *endptr;
 
           if (argc < 3)
             die ("--bind-data takes two arguments");
 
-          file_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || file_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          file_fd = parse_fd_arg (argv[1]);
 
           op = setup_op_new (SETUP_MAKE_BIND_FILE);
           op->fd = file_fd;
@@ -1765,14 +1769,11 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--ro-bind-data") == 0)
         {
           int file_fd;
-          char *endptr;
 
           if (argc < 3)
             die ("--ro-bind-data takes two arguments");
 
-          file_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || file_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          file_fd = parse_fd_arg (argv[1]);
 
           op = setup_op_new (SETUP_MAKE_RO_BIND_FILE);
           op->fd = file_fd;
@@ -1806,14 +1807,11 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--sync-fd") == 0)
         {
           int the_fd;
-          char *endptr;
 
           if (argc < 2)
             die ("--sync-fd takes an argument");
 
-          the_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || the_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          the_fd = parse_fd_arg (argv[1]);
 
           opt_sync_fd = the_fd;
 
@@ -1823,14 +1821,11 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--block-fd") == 0)
         {
           int the_fd;
-          char *endptr;
 
           if (argc < 2)
             die ("--block-fd takes an argument");
 
-          the_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || the_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          the_fd = parse_fd_arg (argv[1]);
 
           opt_block_fd = the_fd;
 
@@ -1840,14 +1835,11 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--userns-block-fd") == 0)
         {
           int the_fd;
-          char *endptr;
 
           if (argc < 2)
             die ("--userns-block-fd takes an argument");
 
-          the_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || the_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          the_fd = parse_fd_arg (argv[1]);
 
           opt_userns_block_fd = the_fd;
 
@@ -1857,14 +1849,11 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--info-fd") == 0)
         {
           int the_fd;
-          char *endptr;
 
           if (argc < 2)
             die ("--info-fd takes an argument");
 
-          the_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || the_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          the_fd = parse_fd_arg (argv[1]);
 
           opt_info_fd = the_fd;
 
@@ -1874,14 +1863,11 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--json-status-fd") == 0)
         {
           int the_fd;
-          char *endptr;
 
           if (argc < 2)
             die ("--json-status-fd takes an argument");
 
-          the_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || the_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          the_fd = parse_fd_arg (argv[1]);
 
           opt_json_status_fd = the_fd;
 
@@ -1891,14 +1877,11 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--seccomp") == 0)
         {
           int the_fd;
-          char *endptr;
 
           if (argc < 2)
             die ("--seccomp takes an argument");
 
-          the_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || the_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          the_fd = parse_fd_arg (argv[1]);
 
           opt_seccomp_fd = the_fd;
 
@@ -1908,14 +1891,11 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--userns") == 0)
         {
           int the_fd;
-          char *endptr;
 
           if (argc < 2)
             die ("--userns takes an argument");
 
-          the_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || the_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          the_fd = parse_fd_arg (argv[1]);
 
           opt_userns_fd = the_fd;
 
@@ -1925,14 +1905,11 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--userns2") == 0)
         {
           int the_fd;
-          char *endptr;
 
           if (argc < 2)
             die ("--userns2 takes an argument");
 
-          the_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || the_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          the_fd = parse_fd_arg (argv[1]);
 
           opt_userns2_fd = the_fd;
 
@@ -1942,14 +1919,11 @@ parse_args_recurse (int          *argcp,
       else if (strcmp (arg, "--pidns") == 0)
         {
           int the_fd;
-          char *endptr;
 
           if (argc < 2)
             die ("--pidns takes an argument");
 
-          the_fd = strtol (argv[1], &endptr, 10);
-          if (argv[1][0] == 0 || endptr[0] != 0 || the_fd < 0)
-            die ("Invalid fd: %s", argv[1]);
+          the_fd = parse_fd_arg (argv[1]);
 
           opt_pidns_fd = the_fd;
 


### PR DESCRIPTION
This is a pure cleanup patch and should not affect anything. I was gonna use it for some other work which required yet another fd argument, but that fell through.