### PR TITLE
configure.ac: Fix selinux PKG_CHECK_MODULES

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,20 +41,20 @@ AC_ARG_WITH([bash-completion-dir],
     [],
     [with_bash_completion_dir=yes])
 
-if test "x$with_bash_completion_dir" = "xyes"; then
+AS_IF([test "x$with_bash_completion_dir" = "xyes"], [
     PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
         [BASH_COMPLETION_DIR="`pkg-config --variable=completionsdir bash-completion`"],
         [BASH_COMPLETION_DIR="$datadir/bash-completion/completions"])
-else
+], [
     BASH_COMPLETION_DIR="$with_bash_completion_dir"
-fi
+])
 
 AC_SUBST([BASH_COMPLETION_DIR])
 AM_CONDITIONAL([ENABLE_BASH_COMPLETION],[test "x$with_bash_completion_dir" != "xno"])
 # ------------------------------------------------------------------------------
 have_selinux=no
 AC_ARG_ENABLE(selinux, AS_HELP_STRING([--disable-selinux], [Disable optional SELINUX support]))
-if test "x$enable_selinux" != "xno"; then
+AS_IF([test "x$enable_selinux" != "xno"], [
         PKG_CHECK_MODULES([SELINUX], [libselinux >= 2.1.9],
                 [AC_DEFINE(HAVE_SELINUX, 1, [Define if SELinux is available])
                  have_selinux=yes
@@ -63,7 +63,7 @@ if test "x$enable_selinux" != "xno"; then
         if test "x$have_selinux" = xno -a "x$enable_selinux" = xyes; then
                 AC_MSG_ERROR([*** SELinux support requested but libraries not found])
         fi
-fi
+])
 AM_CONDITIONAL(HAVE_SELINUX, [test "$have_selinux" = "yes"])
 
 dnl Keep this in sync with ostree, except remove -Werror=declaration-after-statement


### PR DESCRIPTION
The first time PKG_CHECK_MODULES is called also checks for pkg-config.
If that first call is in an optional block then later calls to
PKG_CHECK_MODULES will fail.

See https://autotools.io/pkgconfig/pkg_check_modules.html
Section 3.4. Optional Modules

Test with:
This fails:
./autogen.sh --with-bash-completion-dir=/usr/share/bash-completion/completions --enable-selinux

This succeeds:
./autogen.sh --with-bash-completion-dir=yes --enable-selinux

Signed-off-by: Jason Zaman <jason@perfinion.com>