### PR TITLE
Mount new tmpfs filesystems with noexec flag

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1023,7 +1023,7 @@ privileged_op (int         privileged_op_socket,
     case PRIV_SEP_OP_TMPFS_MOUNT:
       {
         cleanup_free char *opt = label_mount ("mode=0755", opt_file_label);
-        if (mount ("tmpfs", arg1, "tmpfs", MS_NOSUID | MS_NODEV, opt) != 0)
+        if (mount ("tmpfs", arg1, "tmpfs", MS_NOSUID | MS_NOEXEC | MS_NODEV, opt) != 0)
           die_with_error ("Can't mount tmpfs on %s", arg1);
         break;
       }


### PR DESCRIPTION
On systems which strictly use noexec flag for filesystems, creating new, arbitrary ones with exec flag means apps in sandbox will have more privileges than they would have on host.

This won't cover interpreted code but blocking execution of such code is work in progress: https://patchwork.kernel.org/patch/11135563/ and if it's completed then it will hit by the same issue with lack of noexec flag on new tmpfs filesystems.

Moreover on such restricted systems there could be no interpreters available in executable paths in container which again may be bypassed by putting interpreter to newly created  executable path and run it from it.