### PR TITLE
Ensure we're always clearing the cap bounding set

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2766,6 +2766,9 @@ main (int    argc,
       if (unshare (CLONE_NEWUSER))
         die_with_error ("unshare user ns");
 
+      /* We're in a new user namespace, we got back the bounding set, clear it again */
+      drop_cap_bounding_set (FALSE);
+
       write_uid_gid_map (opt_sandbox_uid, ns_uid,
                          opt_sandbox_gid, ns_gid,
                          -1, FALSE, FALSE);


### PR DESCRIPTION
In the non-setuid case if we're not running as uid 0 in the final
namespace but we need devpts (e.g. use --dev) we mount the devpts as
uid and then change to the actual numberical uid at the end. This
final unshare(CLONE_NEWPID) will reset tha cap bounding set we
previously cleared.

This change clears the cap bounding set again after the unshare call.

This is not really a security problem because we always set
NO_NEW_PRIVS which is essentially a superset of capability bounds, so
there is no way the container can use the bounding set to gain
caps. However its nice to be consistent and not display setting
which look like potential problems.

Fixes https://github.com/containers/bubblewrap/issues/350

See 6b3dd4f10c23f23a2f3c3ec0f0d27ffc1149194c for the original change
the drops the cap bounding set in the first location.