### PR TITLE
ensure pkg-config is found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_SYS_LARGEFILE
 
 AC_PROG_CC
 AM_PROG_CC_C_O
+PKG_PROG_PKG_CONFIG([])
 
 AC_CHECK_HEADERS([sys/capability.h], [], [AC_MSG_ERROR([*** POSIX caps headers not found])])
 


### PR DESCRIPTION
bubblewrap uses pkg-config to find e.g. the selinux libraries.
pkg-config itself is not looked for if the path for the bash
completions is given by command line.
this call makes sure that pkg-config is found either way.

downstream bug: https://bugs.gentoo.org/674312