### PR TITLE
Fix broken test

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -179,11 +179,13 @@ if test -n "${bwrap_is_suid:-}"; then
     echo "ok - # SKIP no --cap-add support"
 else
     BWRAP_RECURSE="$BWRAP --unshare-user --uid 0 --gid 0 --cap-add ALL --bind / / --bind /proc /proc"
-    $BWRAP_RECURSE -- $BWRAP --unshare-all --bind / / --bind /proc /proc echo hello > recursive_proc.txt
+
+    # $BWRAP May be inaccessable due to the user namespace so use /proc/self/exe
+    $BWRAP_RECURSE -- /proc/self/exe --unshare-all --bind / / --bind /proc /proc echo hello > recursive_proc.txt
     assert_file_has_content recursive_proc.txt "hello"
     echo "ok - can mount /proc recursively"
 
-    $BWRAP_RECURSE -- $BWRAP --unshare-all  ${BWRAP_RO_HOST_ARGS} findmnt > recursive-newroot.txt
+    $BWRAP_RECURSE -- /proc/self/exe --unshare-all  ${BWRAP_RO_HOST_ARGS} findmnt > recursive-newroot.txt
     assert_file_has_content recursive-newroot.txt "/usr"
     echo "ok - can pivot to new rootfs recursively"
 fi

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -178,7 +178,7 @@ if test -n "${bwrap_is_suid:-}"; then
     echo "ok - # SKIP no --cap-add support"
     echo "ok - # SKIP no --cap-add support"
 else
-    BWRAP_RECURSE="$BWRAP --unshare-all --uid 0 --gid 0 --cap-add ALL --bind / / --bind /proc /proc"
+    BWRAP_RECURSE="$BWRAP --unshare-user --uid 0 --gid 0 --cap-add ALL --bind / / --bind /proc /proc"
     $BWRAP_RECURSE -- $BWRAP --unshare-all --bind / / --bind /proc /proc echo hello > recursive_proc.txt
     assert_file_has_content recursive_proc.txt "hello"
     echo "ok - can mount /proc recursively"


### PR DESCRIPTION
This test runs Bubblewrap in a pid namespace with `/proc` for the parent namespace. As a result Bubblewrap fails with an error in `namespace_ids_read` unless there is a process with pid 3 in the parent namespace.

Test with: `unshare -rpfm --mount-proc make check`

Also the test fails when run sudo root if root does not have permission to access the path of `test-bwrap`, I fix this by using `/proc/self/exe` to run nested `bwrap`.