### PR TITLE
Prettify demo script

### DIFF
--- a/demos/bubblewrap-shell.sh
+++ b/demos/bubblewrap-shell.sh
@@ -9,26 +9,27 @@
 # Another way to build on this example is to remove --share-net to disable
 # networking.
 set -euo pipefail
-(exec bwrap --ro-bind /usr /usr \
-      --dir /tmp \
-      --dir /var \
-      --symlink ../tmp var/tmp \
-      --proc /proc \
-      --dev /dev \
-      --ro-bind /etc/resolv.conf /etc/resolv.conf \
-      --symlink usr/lib /lib \
-      --symlink usr/lib64 /lib64 \
-      --symlink usr/bin /bin \
-      --symlink usr/sbin /sbin \
-      --chdir / \
-      --unshare-all \
-      --share-net \
-      --die-with-parent \
-      --dir /run/user/$(id -u) \
+(exec bwrap                                        \
+      --ro-bind /usr /usr                          \
+      --ro-bind /etc/resolv.conf /etc/resolv.conf  \
+      --dir /tmp                                   \
+      --dir /var                                   \
+      --dir /run/user/$(id -u)                     \
+      --proc /proc                                 \
+      --dev /dev                                   \
+      --symlink ../tmp var/tmp                     \
+      --symlink usr/lib /lib                       \
+      --symlink usr/lib64 /lib64                   \
+      --symlink usr/bin /bin                       \
+      --symlink usr/sbin /sbin                     \
+      --chdir /                                    \
+      --unshare-all                                \
+      --share-net                                  \
+      --die-with-parent                            \
       --setenv XDG_RUNTIME_DIR "/run/user/`id -u`" \
-      --setenv PS1 "bwrap-demo$ " \
-      --file 11 /etc/passwd \
-      --file 12 /etc/group \
-      /bin/sh) \
-    11< <(getent passwd $UID 65534) \
+      --setenv PS1 "bwrap-demo$ "                  \
+      --file 11 /etc/passwd                        \
+      --file 12 /etc/group                         \
+      /bin/sh)                                     \
+    11< <(getent passwd $UID 65534)                \
     12< <(getent group $(id -g) 65534)


### PR DESCRIPTION
Added spaces to make the trailing line-continuation slashes all line up
in the same column. Also moved a few command-line flags around to group
together flags of same kind.

Note to reviewers: use command `git diff -w` to see the changes to exclude
the whitespace diff.