### PR TITLE
Stop installing python-is-python2 for CI

### DIFF
--- a/ci/builddeps.sh
+++ b/ci/builddeps.sh
@@ -65,7 +65,6 @@ if dpkg-vendor --derives-from Debian; then
         libselinux1-dev \
         libtool \
         pkg-config \
-        python-is-python2 \
         python3 \
         xsltproc \
         ${NULL+}


### PR DESCRIPTION
Merging #344 made this unnecessary.