### PR TITLE
Add --clearenv option

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -244,6 +244,7 @@ usage (int ecode, FILE *out)
            "    --gid GID                    Custom gid in the sandbox (requires --unshare-user or --userns)\n"
            "    --hostname NAME              Custom hostname in the sandbox (requires --unshare-uts)\n"
            "    --chdir DIR                  Change directory to DIR\n"
+           "    --clearenv                   Unset all environment variables\n"
            "    --setenv VAR VALUE           Set an environment variable\n"
            "    --unsetenv VAR               Unset an environment variable\n"
            "    --lock-file DEST             Take a lock on DEST while sandbox is running\n"
@@ -2083,6 +2084,10 @@ parse_args_recurse (int          *argcp,
 
           argv += 1;
           argc -= 1;
+        }
+      else if (strcmp (arg, "--clearenv") == 0)
+        {
+          xclearenv ();
         }
       else if (strcmp (arg, "--setenv") == 0)
         {

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -80,7 +80,7 @@ if [ -z "${BWRAP_MUST_WORK-}" ] && ! $RUN true; then
     skip Seems like bwrap is not working at all. Maybe setuid is not working
 fi
 
-echo "1..55"
+echo "1..56"
 
 # Test help
 ${BWRAP} --help > help.txt
@@ -530,5 +530,14 @@ $RUN \
     stat -c '%a' /tmp/file < /dev/null > file-permissions
 assert_file_has_content file-permissions '^640$'
 echo "ok - files have expected permissions"
+
+FOO= BAR=baz $RUN --setenv FOO bar sh -c 'echo "$FOO$BAR"' > stdout
+assert_file_has_content stdout barbaz
+FOO=wrong BAR=baz $RUN --setenv FOO bar sh -c 'echo "$FOO$BAR"' > stdout
+assert_file_has_content stdout barbaz
+FOO=wrong BAR=baz $RUN --unsetenv FOO sh -c 'printf "%s%s" "$FOO" "$BAR"' > stdout
+printf baz > reference
+assert_files_equal stdout reference
+echo "ok - environment manipulation"
 
 echo "ok - End of test"

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -538,6 +538,9 @@ assert_file_has_content stdout barbaz
 FOO=wrong BAR=baz $RUN --unsetenv FOO sh -c 'printf "%s%s" "$FOO" "$BAR"' > stdout
 printf baz > reference
 assert_files_equal stdout reference
+FOO=wrong BAR=wrong $RUN --clearenv /usr/bin/env > stdout
+echo "PWD=$(pwd -P)" > reference
+assert_files_equal stdout reference
 echo "ok - environment manipulation"
 
 echo "ok - End of test"

--- a/utils.c
+++ b/utils.c
@@ -231,6 +231,13 @@ has_prefix (const char *str,
 }
 
 void
+xclearenv (void)
+{
+  if (clearenv () != 0)
+    die_with_error ("clearenv failed");
+}
+
+void
 xsetenv (const char *name, const char *value, int overwrite)
 {
   if (setenv (name, value, overwrite))

--- a/utils.h
+++ b/utils.h
@@ -62,6 +62,7 @@ void *xrealloc (void  *ptr,
                 size_t size);
 char *xstrdup (const char *str);
 void  strfreev (char **str_array);
+void  xclearenv (void);
 void  xsetenv (const char *name,
                const char *value,
                int         overwrite);


### PR DESCRIPTION
* test-run: Test --setenv, --unsetenv

* Add --clearenv option
    
    This allows environment variables to be set when running bwrap itself
    (perhaps a custom LD_LIBRARY_PATH), but cleared for the command that
    runs in the container, without having to enumerate all the variables.
    
    Because PWD is set later, as a side-effect of changing directory, this
    actually clears everything except PWD.

    A portable program would check for clearenv() (and if not found, fall
    back to using environ = NULL), but bubblewrap is Linux-specific, and
    Linux C libraries (at least glibc and musl) do have clearenv().