### PR TITLE
Add support for bind-mount on case-insensitive filesystems

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -861,14 +861,6 @@ get_newroot_path (const char *path)
   return strconcat ("/newroot/", path);
 }
 
-static char *
-get_oldroot_path (const char *path)
-{
-  while (*path == '/')
-    path++;
-  return strconcat ("/oldroot/", path);
-}
-
 static void
 write_uid_gid_map (uid_t sandbox_uid,
                    uid_t parent_uid,

--- a/utils.c
+++ b/utils.c
@@ -764,6 +764,37 @@ read_pid_from_socket (int socket)
   die ("No pid returned on socket");
 }
 
+/* Sets errno on error (== NULL),
+ * Always ensures terminating zero */
+char *
+readlink_malloc (const char *pathname)
+{
+  size_t size = 50;
+  ssize_t n;
+  cleanup_free char *value = NULL;
+
+  do
+    {
+      size *= 2;
+      value = xrealloc (value, size);
+      n = readlink (pathname, value, size - 1);
+      if (n < 0)
+        return NULL;
+    }
+  while (size - 2 < n);
+
+  value[n] = 0;
+  return steal_pointer (&value);
+}
+
+char *
+get_oldroot_path (const char *path)
+{
+  while (*path == '/')
+    path++;
+  return strconcat ("/oldroot/", path);
+}
+
 int
 raw_clone (unsigned long flags,
            void         *child_stack)

--- a/utils.h
+++ b/utils.h
@@ -112,6 +112,8 @@ int   mkdir_with_parents (const char *pathname,
 void create_pid_socketpair (int sockets[2]);
 void send_pid_on_socket (int socket);
 int  read_pid_from_socket (int socket);
+char *get_oldroot_path (const char *path);
+char *readlink_malloc (const char *pathname);
 
 /* syscall wrappers */
 int   raw_clone (unsigned long flags,


### PR DESCRIPTION
If we are using a case-insensitive filesystem the bind-mount operation
might fail when `/proc/self/mountinfo` is checked.

In a case-insensitive filesystem, if we ask to mount a certain
directory, e.g. '/CI_fs/foo', the kernel might add its entry in
`mountinfo` as '/CI_fs/FOO'. This happens because the kernel populates
`mountinfo` with whatever case combination first appeared in the dcache.

With this patch we open the requested path and look at its
`/proc/self/fd`, using readlink(), to get the path case combination that
the kernel is also expected to be using.

---

/cc @smcv

A reproducer for this issue is:
```
mkdir /media/CI_dir
chattr +F /media/CI_dir  # Set directory as case-insensitive
mkdir /media/CI_dir/my_dir
echo 3 >  /proc/sys/vm/drop_caches  # Drop dcache
ls /media/CI_dir/MY_DIR

bwrap --dev-bind /bin /bin \
--dev /dev \
--bind /lib /lib \
--bind /usr /usr \
--symlink usr/lib /lib64 \
--ro-bind /media /media \
--bind /media/CI_dir/my_dir /media/CI_dir/my_dir \
-- /usr/bin/bash

bwrap: Can't bind mount /oldroot//media/CI_dir/my_dir on /media/CI_dir/my_dir: Invalid argument
```

Please let me know what do you think about this solution.