### PR TITLE
Create files as mount points with read-only permissions

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1103,7 +1103,7 @@ setup_newroot (bool unshare_pid,
               if (ensure_dir (dest, 0755) != 0)
                 die_with_error ("Can't mkdir %s", op->dest);
             }
-          else if (ensure_file (dest, 0666) != 0)
+          else if (ensure_file (dest, 0444) != 0)
             die_with_error ("Can't create file at %s", op->dest);
 
           privileged_op (privileged_op_socket,
@@ -1174,7 +1174,7 @@ setup_newroot (bool unshare_pid,
             {
               cleanup_free char *node_dest = strconcat3 (dest, "/", devnodes[i]);
               cleanup_free char *node_src = strconcat ("/oldroot/dev/", devnodes[i]);
-              if (create_file (node_dest, 0666, NULL) != 0)
+              if (create_file (node_dest, 0444, NULL) != 0)
                 die_with_error ("Can't create file %s/%s", op->dest, devnodes[i]);
               privileged_op (privileged_op_socket,
                              PRIV_SEP_OP_BIND_MOUNT, BIND_DEVICES,
@@ -1227,7 +1227,7 @@ setup_newroot (bool unshare_pid,
               cleanup_free char *src_tty_dev = strconcat ("/oldroot", host_tty_dev);
               cleanup_free char *dest_console = strconcat (dest, "/console");
 
-              if (create_file (dest_console, 0666, NULL) != 0)
+              if (create_file (dest_console, 0444, NULL) != 0)
                 die_with_error ("creating %s/console", op->dest);
 
               privileged_op (privileged_op_socket,
@@ -1295,7 +1295,7 @@ setup_newroot (bool unshare_pid,
 
             assert (dest != NULL);
 
-            if (ensure_file (dest, 0666) != 0)
+            if (ensure_file (dest, 0444) != 0)
               die_with_error ("Can't create file at %s", op->dest);
 
             privileged_op (privileged_op_socket,

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -80,7 +80,7 @@ if ! $RUN true; then
     skip Seems like bwrap is not working at all. Maybe setuid is not working
 fi
 
-echo "1..49"
+echo "1..50"
 
 # Test help
 ${BWRAP} --help > help.txt
@@ -384,5 +384,18 @@ else
     echo "ok - Test --pidns"
 fi
 
+touch some-file
+mkdir -p some-dir
+rm -fr new-dir-mountpoint
+rm -fr new-file-mountpoint
+$RUN \
+    --bind "$(pwd -P)/some-dir" "$(pwd -P)/new-dir-mountpoint" \
+    --bind "$(pwd -P)/some-file" "$(pwd -P)/new-file-mountpoint" \
+    true
+command stat -c '%a' new-dir-mountpoint > new-dir-permissions
+assert_file_has_content new-dir-permissions 755
+command stat -c '%a' new-file-mountpoint > new-file-permissions
+assert_file_has_content new-file-permissions 444
+echo "ok - Files and directories created as mount points have expected permissions"
 
 echo "ok - End of test"


### PR DESCRIPTION
If two mount namespaces can both see a directory, and we bind-mount a
non-directory into that directory, we have to create a non-directory
to mount it onto:

    $ ls -l ~/tmp/mountpoint
    ls: cannot access '/home/smcv/tmp/mountpoint': No such file or directory
    $ bwrap --bind / / --bind /etc/os-release ~/tmp/mountpoint true
    $ ls -l ~/tmp/mountpoint
    -rw-rw-rw- 1 smcv smcv 0 Feb 16 10:27 /home/smcv/tmp/mountpoint

The mount point is currently created as an empty world-writable file,
but this doesn't seem like a least-astonishment thing to do.
Create it with read-only permissions instead, to make it clearer that
it's just a placeholder and prevent other users from filling it.

Resolves: https://github.com/containers/bubblewrap/issues/337