### PR TITLE
Add CI using Github workflows

### DIFF
--- a/.github/workflows/block-autosquash-commits.yml
+++ b/.github/workflows/block-autosquash-commits.yml
@@ -1,0 +1,15 @@
+on: pull_request
+
+name: Pull Requests
+
+jobs:
+  message-check:
+    name: Block Autosquash Commits
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Block Autosquash Commits
+        uses: xt0rted/block-autosquash-commits-action@v2.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,94 @@
+name: CI checks
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  check:
+    name: Build with gcc and test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out
+      uses: actions/checkout@v1
+    - name: Install build-dependencies
+      run: sudo ./ci/builddeps.sh
+    - name: Create logs dir
+      run: mkdir test-logs
+    - name: autogen.sh
+      run: NOCONFIGURE=1 ./autogen.sh
+    - name: configure
+      run: |
+        mkdir _build
+        pushd _build
+        ../configure \
+          --enable-man \
+          --enable-selinux \
+          ${NULL+}
+        popd
+      env:
+        CFLAGS: >-
+          -O2
+          -Wp,-D_FORTIFY_SOURCE=2
+          -fsanitize=address
+          -fsanitize=undefined
+    - name: make
+      run: make -C _build -j $(getconf _NPROCESSORS_ONLN) V=1
+    - name: smoke-test
+      run: |
+        set -x
+        ./_build/bwrap --bind / / --tmpfs /tmp true
+      env:
+        ASAN_OPTIONS: detect_leaks=0
+    - name: check
+      run: |
+        make -C _build -j $(getconf _NPROCESSORS_ONLN) check VERBOSE=1 BWRAP_MUST_WORK=1
+      env:
+        ASAN_OPTIONS: detect_leaks=0
+    - name: Collect overall test logs on failure
+      if: failure()
+      run: mv _build/test-suite.log test-logs/ || true
+    - name: Collect individual test logs on cancel
+      if: failure() || cancelled()
+      run: mv _build/tests/*.log test-logs/ || true
+    - name: Upload test logs
+      uses: actions/upload-artifact@v1
+      if: failure() || cancelled()
+      with:
+        name: test logs
+        path: test-logs
+
+  clang:
+    name: Build with clang and analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - cpp
+    steps:
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Check out
+      uses: actions/checkout@v1
+    - name: Install build-dependencies
+      run: sudo ./ci/builddeps.sh --clang
+    - name: autogen.sh
+      run: NOCONFIGURE=1 ./autogen.sh
+    - name: configure
+      run: ./configure --enable-selinux
+      env:
+        CC: clang
+        CFLAGS: >-
+          -O2
+          -Werror=unused-variable
+    - name: make
+      run: make -j $(getconf _NPROCESSORS_ONLN) V=1
+    - name: CodeQL analysis
+      uses: github/codeql-action/analyze@v1

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,7 @@ check_PROGRAMS = test-bwrap
 test-bwrap: bwrap
 	rm -rf test-bwrap
 	cp bwrap test-bwrap
+	chmod 0755 test-bwrap
 if PRIV_MODE_SETUID
 	$(SUDO_BIN) chown root test-bwrap
 	$(SUDO_BIN) chmod u+s test-bwrap

--- a/ci/builddeps.sh
+++ b/ci/builddeps.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Copyright 2021 Simon McVittie
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+set -eux
+set -o pipefail
+
+usage () {
+    if [ "${1-2}" -ne 0 ]; then
+        exec >&2
+    fi
+    cat <<EOF
+Usage: see source code
+EOF
+    exit "${1-2}"
+}
+
+opt_clang=
+
+getopt_temp="help"
+getopt_temp="$getopt_temp,clang"
+
+getopt_temp="$(getopt -o '' --long "${getopt_temp}" -n "$0" -- "$@")"
+eval set -- "$getopt_temp"
+unset getopt_temp
+
+while true; do
+    case "$1" in
+        (--clang)
+            clang=yes
+            shift
+            ;;
+
+        (--help)
+            usage 0
+            # not reached
+            ;;
+
+        (--)
+            shift
+            break
+            ;;
+
+        (*)
+            echo 'Error parsing options' >&2
+            usage 2
+            ;;
+    esac
+done
+
+# No more arguments please
+for arg in "$@"; do
+    usage 2
+done
+
+if dpkg-vendor --derives-from Debian; then
+    apt-get -y update
+    apt-get -q -y install \
+        autoconf \
+        automake \
+        build-essential \
+        docbook-xml \
+        docbook-xsl \
+        libcap-dev \
+        libselinux1-dev \
+        libtool \
+        pkg-config \
+        python-is-python2 \
+        python3 \
+        xsltproc \
+        ${NULL+}
+
+    if [ -n "${opt_clang}" ]; then
+        apt-get -y install clang
+    fi
+
+    exit 0
+fi
+
+if command -v yum; then
+    yum -y install \
+        'pkgconfig(libselinux)' \
+        /usr/bin/eu-readelf \
+        autoconf \
+        automake \
+        docbook-style-xsl \
+        gcc \
+        git \
+        libasan \
+        libcap-devel \
+        libtool \
+        libtsan \
+        libubsan \
+        libxslt \
+        make \
+        redhat-rpm-config \
+        rsync \
+        ${NULL+}
+
+    if [ -n "${opt_clang}" ]; then
+        yum -y install clang
+    fi
+
+    exit 0
+fi
+
+echo "Unknown distribution" >&2
+exit 1
+
+# vim:set sw=4 sts=4 et:

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -162,3 +162,11 @@ skip() {
 extract_child_pid() {
     grep child-pid "$1" | sed "s/^.*: \([0-9]*\).*/\1/"
 }
+
+report_err () {
+  local exit_status="$?"
+  { { local BASH_XTRACEFD=3; } 2> /dev/null
+  echo "Unexpected nonzero exit status $exit_status while running: $BASH_COMMAND" >&2
+  } 3> /dev/null
+}
+trap report_err ERR

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -76,7 +76,7 @@ fi
 # Default arg, bind whole host fs to /, tmpfs on /tmp
 RUN="${BWRAP} --bind / / --tmpfs /tmp"
 
-if ! $RUN true; then
+if [ -z "${BWRAP_MUST_WORK-}" ] && ! $RUN true; then
     skip Seems like bwrap is not working at all. Maybe setuid is not working
 fi
 


### PR DESCRIPTION
* build: Make sure test-bwrap is executable

* libtest-core: On failure, make it clearer what has happened
    
    If we fail as a result of `set -x`, It's often not completely obvious
    which command failed or how. Use a trap on ERR to show the command that
    failed, and its exit status.

    (Similar to ostreedev/ostree#2350)

* tests: Add a way to assert that bwrap is fully supported
    
    If we're running on an operating system configuration where bwrap is
    expected to work (unprivileged user namespace creation is allowed,
    not in a chroot, not in a container, etc.), run with BWRAP_MUST_WORK=1.

* Add CI using Github workflows
    
    Loosely based on the configuration used in Flatpak.