### PR TITLE
rbwrap: Implement ability to switch AppArmor profiles

### DIFF
--- a/bwrap.xml
+++ b/bwrap.xml
@@ -284,6 +284,13 @@
       </para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--apparmor-profile <arg choice="plain">PROFILE</arg></option></term>
+      <listitem><para>
+	AppArmor Profile from the sandbox. On an AppArmor system you can specify the
+	profile for the sandbox process(s). Requires writable procfs.
+      </para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--block-fd <arg choice="plain">FD</arg></option></term>
       <listitem><para>
 	Block the sandbox on reading from FD until some data is available.

--- a/utils.c
+++ b/utils.c
@@ -824,3 +824,16 @@ label_exec (const char *exec_label)
 #endif
   return 0;
 }
+
+int apparmor_change_profile (const char *profile)
+{
+  cleanup_free char *data = NULL;
+
+  if (!profile)
+    return 0;
+  data = strconcat ("changeprofile ", profile);
+  if (write_file_at (-1, "/proc/self/attr/apparmor/current", data) == -1)
+    return -1;
+
+  return 0;
+}

--- a/utils.h
+++ b/utils.h
@@ -122,6 +122,7 @@ char *label_mount (const char *opt,
                    const char *mount_label);
 int   label_exec (const char *exec_label);
 int   label_create_file (const char *file_label);
+int   apparmor_change_profile (const char *profile);
 
 static inline void
 cleanup_freep (void *p)


### PR DESCRIPTION
Bubblewrap is currently hard to use in combination with AppArmor
profiles. The root cause of this is that it sets the NO_NEW_PRIVS flag
quite early in the process, and if that flag is set then most AppArmor
profile transitions are disallowed (except for unconfined -> confined
and profile stacking). This makes it rather hard to have a central
profile for bwrap acting as a portal with "normal" profiles. While this
could be solved by granting the bwrap profile itself full permissions to
everything on the system and then only use stacked transitions, this
feels overly dangerous especially considering that bwrap is typically
installed setuid.

To fix this issue, this commit instead introduces the ability to
explicitly transition to a specific target AppArmor profile. This allows
us to perform the transition before we set the NO_NEW_PRIVS flag and
thus make them both work together. There are two downsides to this:

    - NO_NEW_PRIVS must be set at a much later point in time, namely
      after the sandbox has been constructed and the new profile has
      been changed to. While we could switch to the profile at a much
      earlier point in time, this would require the target profile to
      grant permissions required to construct the sandbox. We cannot use
      AppArmor's "change_onexec" transition either: even if we set the
      transition up while NO_NEW_PRIVS is not yet effective, the profile
      switch on exec is going to be denied anyway.

    - In order to allow switching the profile, we need to have a
      writable "/proc". This is required such that we can effect the
      transition via a write to "/proc/self/attr/apparmor/current".

Neither of these downsides should be a problem though: NO_NEW_PRIVS'
main intent is to avoid granting new privileges on execve(2), which it
still does given that execve(2) is the last step. And "/proc" being
writable shouldn't matter much when a pid namespace is in use.

Implement AppArmor profile switching via a new "--apparmor-profile"
switch and document it.

Signed-off-by: Patrick Steinhardt <ps@pks.im>