### PR TITLE
utils: Remove security_context_t casts for libselinux >= 2.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,9 @@ if test "x$enable_selinux" != "xno"; then
         if test "x$have_selinux" = xno -a "x$enable_selinux" = xyes; then
                 AC_MSG_ERROR([*** SELinux support requested but libraries not found])
         fi
+        PKG_CHECK_MODULES([SELINUX_2_3], [libselinux >= 2.3],
+                [AC_DEFINE(HAVE_SELINUX_2_3, 1, [Define if SELinux is version >= 2.3])],
+                [:])
 fi
 AM_CONDITIONAL(HAVE_SELINUX, [test "$have_selinux" = "yes"])
 

--- a/utils.c
+++ b/utils.c
@@ -24,6 +24,13 @@
 #include <selinux/selinux.h>
 #endif
 
+#ifndef HAVE_SELINUX_2_3
+/* libselinux older than 2.3 weren't const-correct */
+#define setexeccon(x) setexeccon ((security_context_t) x)
+#define setfscreatecon(x) setfscreatecon ((security_context_t) x)
+#define security_check_context(x) security_check_context ((security_context_t) x)
+#endif
+
 void
 die_with_error (const char *format, ...)
 {
@@ -65,7 +72,7 @@ die_unless_label_valid (const char *label)
 #ifdef HAVE_SELINUX
   if (is_selinux_enabled () == 1)
     {
-      if (security_check_context ((security_context_t) label) < 0)
+      if (security_check_context (label) < 0)
         die_with_error ("invalid label %s", label);
       return;
     }
@@ -815,7 +822,7 @@ label_create_file (const char *file_label)
 {
 #ifdef HAVE_SELINUX
   if (is_selinux_enabled () > 0 && file_label)
-    return setfscreatecon ((security_context_t) file_label);
+    return setfscreatecon (file_label);
 #endif
   return 0;
 }
@@ -825,7 +832,7 @@ label_exec (const char *exec_label)
 {
 #ifdef HAVE_SELINUX
   if (is_selinux_enabled () > 0 && exec_label)
-    return setexeccon ((security_context_t) exec_label);
+    return setexeccon (exec_label);
 #endif
   return 0;
 }


### PR DESCRIPTION
security_context_t has always been a typedef for `char *` and used more
or less interchangeably with `char *`, but the use of a typedef turned
out to be bad for const-correctness. The function signatures were
changed to take `const char *` in libselinux 2.3, in 2014[1] and the
typedef was formally deprecated in 2020[2].

On very old OSs like Ubuntu 14.04, reinstate the casts to suppress
warnings from -Wdiscarded-qualifiers.

[1] https://github.com/SELinuxProject/selinux/commit/9eb9c9327563
[2] https://github.com/SELinuxProject/selinux/commit/7a124ca27581

---

bubblewrap is compiled with SELinux support on Debian but the majority of Debian systems don't use SELinux, so I'd appreciate it if a user of SELinux-based distros like Red Hat/Fedora could test this.

Marked as draft for now until I try building this in a suitably ancient chroot to exercise the backwards-compatible code path (Ubuntu 12.04 or 14.04).