### PR TITLE
libtest-core: Sync with libostree

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,10 +45,15 @@ include Makefile-docs.am
 LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/build-aux/tap-driver.sh
 LOG_COMPILER =
 TESTS = tests/test-run.sh
-TESTS_ENVIRONMENT = BWRAP=$(abs_top_builddir)/test-bwrap
+TESTS_ENVIRONMENT = \
+	BWRAP=$(abs_top_builddir)/test-bwrap \
+	G_TEST_BUILDDIR=$(abs_top_builddir) \
+	G_TEST_SRCDIR=$(abs_top_srcdir) \
+	$(NULL)
 
 EXTRA_DIST += $(TESTS)
 EXTRA_DIST += tests/libtest-core.sh
+EXTRA_DIST += tests/libtest.sh
 
 if ENABLE_BASH_COMPLETION
 bashcompletiondir = $(BASH_COMPLETION_DIR)

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -9,6 +9,8 @@
 #
 # Copyright (C) 2017 Colin Walters <walters@verbum.org>
 #
+# SPDX-License-Identifier: LGPL-2.0+
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -5,7 +5,7 @@
 #
 # Known copies are in the following repos:
 #
-# - https://github.com/projectatomic/rpm-ostree
+# - https://github.com/coreos/rpm-ostree
 #
 # Copyright (C) 2017 Colin Walters <walters@verbum.org>
 #

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -5,6 +5,7 @@
 #
 # Known copies are in the following repos:
 #
+# - https://github.com/containers/bubblewrap
 # - https://github.com/coreos/rpm-ostree
 #
 # Copyright (C) 2017 Colin Walters <walters@verbum.org>

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -126,9 +126,12 @@ assert_file_has_content () {
 }
 
 assert_file_has_content_literal () {
-    if ! grep -q -F -e "$2" "$1"; then
-        _fatal_print_file "$1" "File '$1' doesn't match fixed string list '$2'"
-    fi
+    fpath=$1; shift
+    for s in "$@"; do
+        if ! grep -q -F -e "$s" "$fpath"; then
+            _fatal_print_file "$fpath" "File '$fpath' doesn't match fixed string list '$s'"
+        fi
+    done
 }
 
 assert_file_has_mode () {

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -178,10 +178,6 @@ skip() {
     exit 0
 }
 
-extract_child_pid() {
-    grep child-pid "$1" | sed "s/^.*: \([0-9]*\).*/\1/"
-}
-
 report_err () {
   local exit_status="$?"
   { { local BASH_XTRACEFD=3; } 2> /dev/null

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -33,13 +33,19 @@ assert_not_reached () {
 }
 
 # Some tests look for specific English strings. Use a UTF-8 version
-# of the C (POSIX) locale if we have one, or fall back to POSIX
+# of the C (POSIX) locale if we have one, or fall back to en_US.UTF-8
 # (https://sourceware.org/glibc/wiki/Proposals/C.UTF-8)
-if locale -a | grep C.UTF-8 >/dev/null; then
-    export LC_ALL=C.UTF-8
+#
+# If we can't find the locale command assume we have support for C.UTF-8
+# (e.g. musl based systems)
+if type -p locale >/dev/null; then
+    export LC_ALL=$(locale -a | grep -iEe '^(C|en_US)\.(UTF-8|utf8)$' | head -n1 || true)
+    if [ -z "${LC_ALL}" ]; then fatal "Can't find suitable UTF-8 locale"; fi
 else
-    export LC_ALL=C
+    export LC_ALL=C.UTF-8
 fi
+# A GNU extension, used whenever LC_ALL is not C
+unset LANGUAGE
 
 # This should really be the default IMO
 export G_DEBUG=fatal-warnings

--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -125,6 +125,16 @@ assert_file_has_content () {
     done
 }
 
+assert_file_has_content_once () {
+    fpath=$1
+    shift
+    for re in "$@"; do
+        if ! test $(grep -e "$re" "$fpath" | wc -l) = "1"; then
+            _fatal_print_file "$fpath" "File '$fpath' doesn't match regexp '$re' exactly once"
+        fi
+    done
+}
+
 assert_file_has_content_literal () {
     fpath=$1; shift
     for s in "$@"; do

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -1,0 +1,37 @@
+# Source library for shell script tests.
+# Add non-bubblewrap-specific code to libtest-core.sh instead.
+#
+# Copyright (C) 2017 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+if [ -n "${G_TEST_SRCDIR:-}" ]; then
+  test_srcdir="${G_TEST_SRCDIR}/tests"
+else
+  test_srcdir=$(dirname $0)
+fi
+
+if [ -n "${G_TEST_BUILDDIR:-}" ]; then
+  test_builddir="${G_TEST_BUILDDIR}/tests"
+else
+  test_builddir=$(dirname $0)
+fi
+
+. "${test_srcdir}/libtest-core.sh"
+
+extract_child_pid() {
+    grep child-pid "$1" | sed "s/^.*: \([0-9]*\).*/\1/"
+}

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -7,7 +7,7 @@ PATH="$PATH:/usr/sbin:/sbin"
 
 srcd=$(cd $(dirname $0) && pwd)
 
-. ${srcd}/libtest-core.sh
+. ${srcd}/libtest.sh
 
 bn=$(basename $0)
 tempdir=$(mktemp -d /var/tmp/tap-test.XXXXXX)


### PR DESCRIPTION
If this PR and ostreedev/ostree#2377 are both accepted, then `libtest-core.sh` will be identical in both projects. Maintainers of both projects, like @cgwalters, are probably in the best position to make this happen.

* libtest-core: Improve C.UTF-8 locale detection
    
    Originally several libostree commits by Philip Withnall, Jan Tojnar,
    Alex Kiernan and Dan Nicholson:
    
    * e48a1bcf "tests: Fix LC_ALL for systems which use .utf8 suffixes"
    * f200efdb "tests: Fix locale detection"
    * 4d17cd91 "tests/core: Fallback to en_US.UTF-8 locale"
    * 3d48021f "tests/core: Assume C.UTF-8 if locale isn't found"
    * 5135a1e5 "tests/core: Really pick C.UTF-8 locale"

* tests/libtest-core: support multiple literal checks

    From: @jlebon 
    
    `grep` supports checking multiple fixed strings separated by newlines,
    but it's mostly just easier to pass them as separate arguments, so let's
    support that. This is now at parity with the similar
    `assert_file_has_content`.

* libtest-core: Add assert_file_has_content_once

    From: @mwleeds 
    
    [Originally part of d2118165 "tests: Check that example symbol isn't
    released" in libostree]

* libtest-core: Separate out bubblewrap-specific parts

    extract_child_pid is specific to bubblewrap and wouldn't be useful to
    share with the canonical copy of libtest-core in libostree.

* libtest-core: Add SPDX-License-Identifier
    
    This realigns the header with the canonical copy in libostree.

* libtest-core: Update URL of rpm-ostree

* libtest-core: Mention bubblewrap as a user of this file