### PR TITLE
bind_mount: Return an error code, and provide a way to display it

### DIFF
--- a/bind-mount.h
+++ b/bind-mount.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "utils.h"
+
 typedef enum {
   BIND_READONLY = (1 << 0),
   BIND_DEVICES = (1 << 2),
@@ -40,6 +42,9 @@ bind_mount_result bind_mount (int           proc_fd,
                               const char   *src,
                               const char   *dest,
                               bind_option_t options);
+
+const char *bind_mount_result_to_string (bind_mount_result res,
+                                         bool *want_errno);
 
 void die_with_bind_result (bind_mount_result res,
                            int               saved_errno,

--- a/bind-mount.h
+++ b/bind-mount.h
@@ -24,7 +24,26 @@ typedef enum {
   BIND_RECURSIVE = (1 << 3),
 } bind_option_t;
 
-int bind_mount (int           proc_fd,
-                const char   *src,
-                const char   *dest,
-                bind_option_t options);
+typedef enum
+{
+  BIND_MOUNT_SUCCESS = 0,
+  BIND_MOUNT_ERROR_MOUNT,
+  BIND_MOUNT_ERROR_REALPATH_DEST,
+  BIND_MOUNT_ERROR_REOPEN_DEST,
+  BIND_MOUNT_ERROR_READLINK_DEST_PROC_FD,
+  BIND_MOUNT_ERROR_FIND_DEST_MOUNT,
+  BIND_MOUNT_ERROR_REMOUNT_DEST,
+  BIND_MOUNT_ERROR_REMOUNT_SUBMOUNT,
+} bind_mount_result;
+
+bind_mount_result bind_mount (int           proc_fd,
+                              const char   *src,
+                              const char   *dest,
+                              bind_option_t options);
+
+void die_with_bind_result (bind_mount_result res,
+                           int               saved_errno,
+                           const char       *format,
+                           ...)
+  __attribute__((__noreturn__))
+  __attribute__((format (printf, 3, 4)));

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1425,6 +1425,19 @@ resolve_symlinks_in_ops (void)
                 die_with_error("Can't find source path %s", old_source);
             }
           break;
+
+        case SETUP_MOUNT_PROC:
+        case SETUP_MOUNT_DEV:
+        case SETUP_MOUNT_TMPFS:
+        case SETUP_MOUNT_MQUEUE:
+        case SETUP_MAKE_DIR:
+        case SETUP_MAKE_FILE:
+        case SETUP_MAKE_BIND_FILE:
+        case SETUP_MAKE_RO_BIND_FILE:
+        case SETUP_MAKE_SYMLINK:
+        case SETUP_REMOUNT_RO_NO_RECURSIVE:
+        case SETUP_SET_HOSTNAME:
+        case SETUP_CHMOD:
         default:
           break;
         }

--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,7 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
         -Werror=incompatible-pointer-types \
         -Werror=misleading-indentation \
 	-Werror=missing-include-dirs -Werror=aggregate-return \
+        -Werror=switch-default \
 ])
 AC_SUBST(WARN_CFLAGS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,7 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
         -Werror=misleading-indentation \
 	-Werror=missing-include-dirs -Werror=aggregate-return \
         -Werror=switch-default \
+        -Wswitch-enum \
 ])
 AC_SUBST(WARN_CFLAGS)
 


### PR DESCRIPTION
* build: Error if a switch lacks a default case
    
    This is a useful way to detect bugs before they happen.

* Handle all enum values in switch

    This makes it clearer that we have thought about whether they need
    symlinks for source resolved, and come to the conclusion that they do not.

* build: Warn if a switch over an enum does not handle all values
    
    This is a useful way to catch possibilities being unhandled.

* bind_mount: Return an error code, and provide a way to display it
    
    This gives us better diagnostic messages on failure, particularly for
    BIND_MOUNT_ERROR_FIND_DEST_MOUNT where we previously said "Invalid
    argument".

* bind-mount: Factor out bind_mount_result_to_string()