### PR TITLE
Add new options to documentation and bash completion

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -278,6 +278,7 @@ usage (int ecode, FILE *out)
            "    --cap-add CAP                Add cap CAP when running as privileged user\n"
            "    --cap-drop CAP               Drop cap CAP when running as privileged user\n"
            "    --perms OCTAL                Set permissions of next argument (--bind-data, --file, etc.)\n"
+           "    --chmod OCTAL PATH           Change permissions of PATH (must already exist)\n"
           );
   exit (ecode);
 }

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -172,6 +172,12 @@
       <term><option>--unsetenv <arg choice="plain">VAR</arg></option></term>
       <listitem><para>Unset an environment variable</para></listitem>
     </varlistentry>
+    <varlistentry>
+      <term><option>--clearenv</option></term>
+      <listitem><para>Unset all environment variables, except for
+        <envar>PWD</envar> and any that are subsequently set by
+        <option>--setenv</option></para></listitem>
+    </varlistentry>
   </variablelist>
   <para>Options for monitoring the sandbox from the outside:</para>
   <variablelist>

--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -7,23 +7,25 @@ _bwrap() {
     local cur prev words cword
     _init_completion || return
 
+	# Please keep sorted in LC_ALL=C order
 	local boolean_options="
 		--as-pid-1
 		--clearenv
 		--help
 		--new-session
+		--unshare-all
 		--unshare-cgroup
 		--unshare-cgroup-try
-		--unshare-user
-		--unshare-user-try
-		--unshare-all
 		--unshare-ipc
 		--unshare-net
 		--unshare-pid
+		--unshare-user
+		--unshare-user-try
 		--unshare-uts
 		--version
 	"
 
+	# Please keep sorted in LC_ALL=C order
 	local options_with_args="
 		$boolean_optons
 		--args

--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -9,6 +9,7 @@ _bwrap() {
 
 	local boolean_options="
 		--as-pid-1
+		--clearenv
 		--help
 		--new-session
 		--unshare-cgroup
@@ -32,6 +33,7 @@ _bwrap() {
 		--cap-add
 		--cap-drop
 		--chdir
+		--chmod
 		--dev
 		--dev-bind
 		--die-with-parent
@@ -43,6 +45,7 @@ _bwrap() {
 		--hostname
 		--info-fd
 		--lock-file
+		--perms
 		--proc
 		--remount-ro
 		--ro-bind


### PR DESCRIPTION
New options introduced in #406, #401 weren't consistently added to all the places that list options.

The zsh completion deliberately isn't included in this PR: I have more changes that I want to make there (see #437).

* Document --chmod in --help

* Document --clearenv in man page

* bash: Include new options in completions

* bash: Sort completions in LC_ALL=C order
    
    Where the order doesn't matter, a deterministic order minimizes
    conflicts.
