### PR TITLE
Improve test-run.sh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,8 @@ test_programs = \
 	$(NULL)
 test_scripts = \
 	tests/test-run.sh \
+	tests/test-specifying-userns.sh \
+	tests/test-specifying-pidns.sh \
 	$(NULL)
 test_extra_programs = \
 	test-bwrap \

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -40,9 +40,8 @@ touch "${tempdir}/.testtmp"
 function cleanup () {
     if test -n "${TEST_SKIP_CLEANUP:-}"; then
         echo "Skipping cleanup of ${test_tmpdir}"
-    else if test -f "${tempdir}/.test"; then
+    elif test -f "${tempdir}/.test"; then
         rm "${tempdir}" -rf
-    fi
     fi
 }
 trap cleanup EXIT

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -21,13 +21,13 @@
 if [ -n "${G_TEST_SRCDIR:-}" ]; then
   test_srcdir="${G_TEST_SRCDIR}/tests"
 else
-  test_srcdir=$(dirname $0)
+  test_srcdir=$(dirname "$0")
 fi
 
 if [ -n "${G_TEST_BUILDDIR:-}" ]; then
   test_builddir="${G_TEST_BUILDDIR}/tests"
 else
-  test_builddir=$(dirname $0)
+  test_builddir=$(dirname "$0")
 fi
 
 . "${test_srcdir}/libtest-core.sh"
@@ -36,17 +36,17 @@ fi
 PATH="$PATH:/usr/sbin:/sbin"
 
 tempdir=$(mktemp -d /var/tmp/tap-test.XXXXXX)
-touch ${tempdir}/.testtmp
+touch "${tempdir}/.testtmp"
 function cleanup () {
     if test -n "${TEST_SKIP_CLEANUP:-}"; then
         echo "Skipping cleanup of ${test_tmpdir}"
-    else if test -f ${tempdir}/.test; then
+    else if test -f "${tempdir}/.test"; then
         rm "${tempdir}" -rf
     fi
     fi
 }
 trap cleanup EXIT
-cd ${tempdir}
+cd "${tempdir}"
 
 : "${BWRAP:=bwrap}"
 if test -u "$(type -p ${BWRAP})"; then
@@ -54,10 +54,10 @@ if test -u "$(type -p ${BWRAP})"; then
 fi
 
 FUSE_DIR=
-for mp in $(cat /proc/self/mounts | grep " fuse[. ]" | grep user_id=$(id -u) | awk '{print $2}'); do
-    if test -d $mp; then
+for mp in $(cat /proc/self/mounts | grep " fuse[. ]" | grep "user_id=$(id -u)" | awk '{print $2}'); do
+    if test -d "$mp"; then
         echo "# Using $mp as test fuse mount"
-        FUSE_DIR=$mp
+        FUSE_DIR="$mp"
         break
     fi
 done
@@ -70,7 +70,7 @@ fi
 
 # This is supposed to be an otherwise readable file in an unreadable (by the user) dir
 UNREADABLE=/root/.bashrc
-if ${is_uidzero} || test -x `dirname $UNREADABLE`; then
+if "${is_uidzero}" || test -x "`dirname "$UNREADABLE"`"; then
     UNREADABLE=
 fi
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -73,7 +73,7 @@ fi
 
 # This is supposed to be an otherwise readable file in an unreadable (by the user) dir
 UNREADABLE=/root/.bashrc
-if "${is_uidzero}" || test -x "`dirname "$UNREADABLE"`"; then
+if "${is_uidzero}" || test -x "$(dirname "$UNREADABLE")"; then
     UNREADABLE=
 fi
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -57,7 +57,7 @@ if test -u "$(type -p ${BWRAP})"; then
 fi
 
 FUSE_DIR=
-for mp in $(cat /proc/self/mounts | grep " fuse[. ]" | grep "user_id=$(id -u)" | awk '{print $2}'); do
+for mp in $(grep " fuse[. ]" /proc/self/mounts | grep "user_id=$(id -u)" | awk '{print $2}'); do
     if test -d "$mp"; then
         echo "# Using $mp as test fuse mount"
         FUSE_DIR="$mp"

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 # Source library for shell script tests.
 # Add non-bubblewrap-specific code to libtest-core.sh instead.
 #
@@ -17,6 +19,8 @@
 # License along with this library; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
+
+set -e
 
 if [ -n "${G_TEST_SRCDIR:-}" ]; then
   test_srcdir="${G_TEST_SRCDIR}/tests"

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -43,8 +43,8 @@ tempdir=$(mktemp -d /var/tmp/tap-test.XXXXXX)
 touch "${tempdir}/.testtmp"
 function cleanup () {
     if test -n "${TEST_SKIP_CLEANUP:-}"; then
-        echo "Skipping cleanup of ${test_tmpdir}"
-    elif test -f "${tempdir}/.test"; then
+        echo "Skipping cleanup of ${tempdir}"
+    elif test -f "${tempdir}/.testtmp"; then
         rm "${tempdir}" -rf
     fi
 }

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -2,11 +2,11 @@
 
 set -xeuo pipefail
 
-srcd=$(cd $(dirname $0) && pwd)
+srcd=$(cd $(dirname "$0") && pwd)
 
 . ${srcd}/libtest.sh
 
-bn=$(basename $0)
+bn=$(basename "$0")
 
 echo "1..56"
 

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -8,7 +8,7 @@ srcd=$(cd $(dirname "$0") && pwd)
 
 bn=$(basename "$0")
 
-echo "1..56"
+echo "1..54"
 
 # Test help
 ${BWRAP} --help > help.txt
@@ -278,41 +278,6 @@ if $RUN --bind "$(pwd)" /tmp/here test -d /tmp/newroot; then
     assert_not_reached "/tmp/newroot should not be visible"
 fi
 echo "ok - we can mount another directory inside /tmp"
-
-# These tests need user namespaces
-if test -n "${bwrap_is_suid:-}"; then
-    echo "ok - # SKIP no setuid support for --unshare-user"
-    echo "ok - # SKIP no setuid support for --unshare-user"
-else
-    mkfifo donepipe
-
-    $RUN --info-fd 42 --unshare-user sh -c 'readlink /proc/self/ns/user > sandbox-userns; cat < donepipe' >/dev/null 42>info.json &
-    while ! test -f sandbox-userns; do sleep 1; done
-    SANDBOX1PID=$(extract_child_pid info.json)
-
-    $RUN  --userns 11 readlink /proc/self/ns/user > sandbox2-userns 11< /proc/$SANDBOX1PID/ns/user
-    echo foo > donepipe
-
-    assert_files_equal sandbox-userns sandbox2-userns
-
-    rm donepipe info.json sandbox-userns
-
-    echo "ok - Test --userns"
-
-    mkfifo donepipe
-    $RUN --info-fd 42 --unshare-user --unshare-pid sh -c 'readlink /proc/self/ns/pid > sandbox-pidns; cat < donepipe' >/dev/null 42>info.json &
-    while ! test -f sandbox-pidns; do sleep 1; done
-    SANDBOX1PID=$(extract_child_pid info.json)
-
-    $RUN --userns 11 --pidns 12 readlink /proc/self/ns/pid > sandbox2-pidns 11< /proc/$SANDBOX1PID/ns/user 12< /proc/$SANDBOX1PID/ns/pid
-    echo foo > donepipe
-
-    assert_files_equal sandbox-pidns sandbox2-pidns
-
-    rm donepipe info.json sandbox-pidns
-
-    echo "ok - Test --pidns"
-fi
 
 touch some-file
 mkdir -p some-dir

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -2,83 +2,11 @@
 
 set -xeuo pipefail
 
-# Make sure /sbin/getpcaps etc. are in our PATH even if non-root
-PATH="$PATH:/usr/sbin:/sbin"
-
 srcd=$(cd $(dirname $0) && pwd)
 
 . ${srcd}/libtest.sh
 
 bn=$(basename $0)
-tempdir=$(mktemp -d /var/tmp/tap-test.XXXXXX)
-touch ${tempdir}/.testtmp
-function cleanup () {
-    if test -n "${TEST_SKIP_CLEANUP:-}"; then
-        echo "Skipping cleanup of ${test_tmpdir}"
-    else if test -f ${tempdir}/.test; then
-        rm "${tempdir}" -rf
-    fi
-    fi
-}
-trap cleanup EXIT
-cd ${tempdir}
-
-: "${BWRAP:=bwrap}"
-if test -u "$(type -p ${BWRAP})"; then
-    bwrap_is_suid=true
-fi
-
-FUSE_DIR=
-for mp in $(cat /proc/self/mounts | grep " fuse[. ]" | grep user_id=$(id -u) | awk '{print $2}'); do
-    if test -d $mp; then
-        echo "# Using $mp as test fuse mount"
-        FUSE_DIR=$mp
-        break
-    fi
-done
-
-if test "$(id -u)" = "0"; then
-    is_uidzero=true
-else
-    is_uidzero=false
-fi
-
-# This is supposed to be an otherwise readable file in an unreadable (by the user) dir
-UNREADABLE=/root/.bashrc
-if ${is_uidzero} || test -x `dirname $UNREADABLE`; then
-    UNREADABLE=
-fi
-
-# https://github.com/projectatomic/bubblewrap/issues/217
-# are we on a merged-/usr system?
-if [ /lib -ef /usr/lib ]; then
-    BWRAP_RO_HOST_ARGS="--ro-bind /usr /usr
-              --ro-bind /etc /etc
-              --dir /var/tmp
-              --symlink usr/lib /lib
-              --symlink usr/lib64 /lib64
-              --symlink usr/bin /bin
-              --symlink usr/sbin /sbin
-              --proc /proc
-              --dev /dev"
-else
-    BWRAP_RO_HOST_ARGS="--ro-bind /usr /usr
-              --ro-bind /etc /etc
-              --ro-bind /bin /bin
-              --ro-bind /lib /lib
-              --ro-bind-try /lib64 /lib64
-              --ro-bind /sbin /sbin
-              --dir /var/tmp
-              --proc /proc
-              --dev /dev"
-fi
-
-# Default arg, bind whole host fs to /, tmpfs on /tmp
-RUN="${BWRAP} --bind / / --tmpfs /tmp"
-
-if [ -z "${BWRAP_MUST_WORK-}" ] && ! $RUN true; then
-    skip Seems like bwrap is not working at all. Maybe setuid is not working
-fi
 
 echo "1..56"
 

--- a/tests/test-specifying-pidns.sh
+++ b/tests/test-specifying-pidns.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+srcd=$(cd $(dirname "$0") && pwd)
+. "${srcd}/libtest.sh"
+
+echo "1..1"
+
+# This test needs user namespaces
+if test -n "${bwrap_is_suid:-}"; then
+    echo "ok - # SKIP no setuid support for --unshare-user"
+else
+    mkfifo donepipe
+    $RUN --info-fd 42 --unshare-user --unshare-pid sh -c 'readlink /proc/self/ns/pid > sandbox-pidns; cat < donepipe' >/dev/null 42>info.json &
+    while ! test -f sandbox-pidns; do sleep 1; done
+    SANDBOX1PID=$(extract_child_pid info.json)
+
+    $RUN --userns 11 --pidns 12 readlink /proc/self/ns/pid > sandbox2-pidns 11< /proc/$SANDBOX1PID/ns/user 12< /proc/$SANDBOX1PID/ns/pid
+    echo foo > donepipe
+
+    assert_files_equal sandbox-pidns sandbox2-pidns
+
+    rm donepipe info.json sandbox-pidns
+
+    echo "ok - Test --pidns"
+fi

--- a/tests/test-specifying-userns.sh
+++ b/tests/test-specifying-userns.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+srcd=$(cd $(dirname "$0") && pwd)
+. "${srcd}/libtest.sh"
+
+echo "1..1"
+
+# This test needs user namespaces
+if test -n "${bwrap_is_suid:-}"; then
+    echo "ok - # SKIP no setuid support for --unshare-user"
+else
+    mkfifo donepipe
+
+    $RUN --info-fd 42 --unshare-user sh -c 'readlink /proc/self/ns/user > sandbox-userns; cat < donepipe' >/dev/null 42>info.json &
+    while ! test -f sandbox-userns; do sleep 1; done
+    SANDBOX1PID=$(extract_child_pid info.json)
+
+    $RUN  --userns 11 readlink /proc/self/ns/user > sandbox2-userns 11< /proc/$SANDBOX1PID/ns/user
+    echo foo > donepipe
+
+    assert_files_equal sandbox-userns sandbox2-userns
+
+    rm donepipe info.json sandbox-userns
+
+    echo "ok - Test --userns"
+fi


### PR DESCRIPTION
* tests: Don't corrupt TAP output
    
    Cater for strict TAP parsers by not printing random strings on stdout;
    either direct them to stderr or to /dev/null, or turn them into TAP
    diagnostics by prefixing "# ".
    
    Automake has a relatively lenient TAP parser, but Meson has a more strict
    TAP parser, so this is a prerequisite for adding a Meson build system.

* Extract some common test setup into libtest.sh
    
    This will allow test-run.sh to be split up into more/smaller scripts.

* tests: Quote more defensively

* tests: Remove unnecessary nesting

* libtest: Add directive and 'set -e' for better shellcheck diagnostics

* tests: Really clean up test temporary directory
    
    The flag file we create and the flag file we check for were not in sync.
    Also similarly correct the variable name in an info message.

* tests: Remove a useless use of cat

* tests: Use $() in preference to backquotes

* tests: Split out tests involving fifos and sharing namespaces
    
    These are more time-consuming than the rest of test-run.sh combined due
    to their use of a wait loop, and separating them out is helpful for the
    possible addition of a Meson build system. The test-case that is moved
    into tests/test-specifying-pidns.sh hangs and times out under
    "meson dist" on Github Actions CI, but not under "meson test" or
    Autotools, and not when tested locally; putting this in its own script
    might help to isolate and fix that failure.

---

Split out from #432, but I think these are good changes even if we stick with Autotools indefinitely.