### PR TITLE
completions: Don't start bash completion with #!

### DIFF
--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -1,5 +1,5 @@
-#!/bin/bash
-#
+# shellcheck shell=bash
+
 # bash completion file for bubblewrap commands
 #
 
@@ -67,3 +67,5 @@ _bwrap() {
 	return 0
 }
 complete -F _bwrap bwrap
+
+# vim:set ft=bash:


### PR DESCRIPTION
bash completions are sourced, not executed, so this doesn't need to be
an executable script.