### PR TITLE
bind-mount: Be more const-correct

### DIFF
--- a/bind-mount.c
+++ b/bind-mount.c
@@ -86,7 +86,7 @@ decode_mountoptions (const char *options)
   int i;
   unsigned long flags = 0;
   static const struct  { int   flag;
-                         char *name;
+                         const char *name;
   } flags_data[] = {
     { 0, "rw" },
     { MS_RDONLY, "ro" },


### PR DESCRIPTION
When compiled with -Wwrite-strings as part of a larger project, gcc and
clang both warn that we're assigning a string constant to a mutable
struct member. There's actually no reason why it should be mutable, so
make it const.