### PR TITLE
bubblewrap: Avoid a -Wjump-misses-init false-positive

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1168,7 +1168,7 @@ setup_newroot (bool unshare_pid,
              problematic (for instance /proc/sysrq-trigger lets you shut down the machine
              if you have write access). We should not have access to these as a non-privileged
              user, but lets cover them anyway just to make sure */
-          const char *cover_proc_dirs[] = { "sys", "sysrq-trigger", "irq", "bus" };
+          static const char * const cover_proc_dirs[] = { "sys", "sysrq-trigger", "irq", "bus" };
           for (i = 0; i < N_ELEMENTS (cover_proc_dirs); i++)
             {
               cleanup_free char *subdir = strconcat3 (dest, "/", cover_proc_dirs[i]);


### PR DESCRIPTION
When building with -Wjump-misses-init as part of a larger project, gcc
reports that we jump past initialization of cover_proc_dirs. This is
technically true, but we only use this variable in the case where it's
initialized, so that's harmless.

However, we can avoid this altogether by making the array static and
constant, which allows it to be moved from initialized data to read-only
data.