### PR TITLE
die_with_error: Save errno sooner

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -38,9 +38,9 @@ die_with_error (const char *format, ...)
   va_list args;
   int errsv;
 
-  fprintf (stderr, "bwrap: ");
-
   errsv = errno;
+
+  fprintf (stderr, "bwrap: ");
 
   va_start (args, format);
   vfprintf (stderr, format, args);


### PR DESCRIPTION
We need to save errno immediately, otherwise it could be overwritten
by a failing library call somewhere in the implementation of fprintf.

---

Noticed while adding `warnv()` so that I could add `warn()`, so that I could implement #454, as preparation for #453, so that I could hopefully fix CVE-2021-41133 in a future-proof way in Flatpak. This is altogether too many layers of yak-shaving.