### PR TITLE
bind-mount: Include failing path in error message

### DIFF
--- a/bind-mount.h
+++ b/bind-mount.h
@@ -42,14 +42,13 @@ typedef enum
 bind_mount_result bind_mount (int           proc_fd,
                               const char   *src,
                               const char   *dest,
-                              bind_option_t options);
-
-const char *bind_mount_result_to_string (bind_mount_result res,
-                                         bool *want_errno);
+                              bind_option_t options,
+                              char        **failing_path);
 
 void die_with_bind_result (bind_mount_result res,
                            int               saved_errno,
+                           const char       *failing_path,
                            const char       *format,
                            ...)
   __attribute__((__noreturn__))
-  __attribute__((format (printf, 3, 4)));
+  __attribute__((format (printf, 4, 5)));

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1005,6 +1005,7 @@ privileged_op (int         privileged_op_socket,
                const char *arg2)
 {
   bind_mount_result bind_result;
+  char *failing_path = NULL;
 
   if (privileged_op_socket != -1)
     {
@@ -1070,23 +1071,25 @@ privileged_op (int         privileged_op_socket,
       break;
 
     case PRIV_SEP_OP_REMOUNT_RO_NO_RECURSIVE:
-      bind_result = bind_mount (proc_fd, NULL, arg2, BIND_READONLY);
+      bind_result = bind_mount (proc_fd, NULL, arg2, BIND_READONLY, &failing_path);
 
       if (bind_result != BIND_MOUNT_SUCCESS)
-        die_with_bind_result (bind_result, errno,
+        die_with_bind_result (bind_result, errno, failing_path,
                               "Can't remount readonly on %s", arg2);
 
+      assert (failing_path == NULL);    /* otherwise we would have died */
       break;
 
     case PRIV_SEP_OP_BIND_MOUNT:
       /* We always bind directories recursively, otherwise this would let us
          access files that are otherwise covered on the host */
-      bind_result = bind_mount (proc_fd, arg1, arg2, BIND_RECURSIVE | flags);
+      bind_result = bind_mount (proc_fd, arg1, arg2, BIND_RECURSIVE | flags, &failing_path);
 
       if (bind_result != BIND_MOUNT_SUCCESS)
-        die_with_bind_result (bind_result, errno,
+        die_with_bind_result (bind_result, errno, failing_path,
                               "Can't bind mount %s on %s", arg1, arg2);
 
+      assert (failing_path == NULL);    /* otherwise we would have died */
       break;
 
     case PRIV_SEP_OP_PROC_MOUNT:


### PR DESCRIPTION
Prompted by flatpak/flatpak#4731, in which a misconfigured SMB automount
was failing to be remounted with ENODEV. This would have been easier to
debug if we knew which path could not be remounted.

---

This is basically a continuation of #434.