### PR TITLE
Bump release number to 0.6.0 for meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'bubblewrap',
   'c',
-  version : '0.5.0',
+  version : '0.6.0',
   meson_version : '>=0.49.0',
   default_options : [
     'warning_level=2',


### PR DESCRIPTION
Meson buildsystem was omitted  during release bump in https://github.com/containers/bubblewrap/commit/b480c5fd0d383ac5d45b6390bd4b48068de6dd6b

Obviously this fix doesn't fix anything if 0.6.0 tag doesn't contain it already. I don't know what correct action should be.