### PR TITLE
Improve error message when clone() fails with ENOSPC

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2790,6 +2790,9 @@ main (int    argc,
             die ("No permissions to creating new namespace, likely because the kernel does not allow non-privileged user namespaces. On e.g. debian this can be enabled with 'sysctl kernel.unprivileged_userns_clone=1'.");
         }
 
+      if (errno == ENOSPC)
+        die ("Creating new namespace failed: nesting depth or /proc/sys/user/max_*_namespaces exceeded (ENOSPC)");
+
       die_with_error ("Creating new namespace failed");
     }
 


### PR DESCRIPTION
In particular, this would have given #371 a clearer error message.