### PR TITLE
Add an option to disable nested user namespaces by setting limit to 1

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -73,6 +73,7 @@ static const char *opt_file_label = NULL;
 static bool opt_as_pid_1;
 
 const char *opt_chdir_path = NULL;
+bool opt_disable_userns = FALSE;
 bool opt_unshare_user = FALSE;
 bool opt_unshare_user_try = FALSE;
 bool opt_unshare_pid = FALSE;
@@ -311,6 +312,7 @@ usage (int ecode, FILE *out)
            "    --unshare-cgroup-try         Create new cgroup namespace if possible else continue by skipping it\n"
            "    --userns FD                  Use this user namespace (cannot combine with --unshare-user)\n"
            "    --userns2 FD                 After setup switch to this user namespace, only useful with --userns\n"
+           "    --disable-userns             Disable further use of user namespaces inside sandbox\n"
            "    --pidns FD                   Use this pid namespace (as parent namespace if using --unshare-pid)\n"
            "    --uid UID                    Custom uid in the sandbox (requires --unshare-user or --userns)\n"
            "    --gid GID                    Custom gid in the sandbox (requires --unshare-user or --userns)\n"
@@ -1777,6 +1779,10 @@ parse_args_recurse (int          *argcp,
           argv++;
           argc--;
         }
+      else if (strcmp (arg, "--disable-userns") == 0)
+        {
+          opt_disable_userns = TRUE;
+        }
       else if (strcmp (arg, "--remount-ro") == 0)
         {
           if (argc < 2)
@@ -2677,6 +2683,12 @@ main (int    argc,
   if (opt_userns_fd != -1 && opt_unshare_user_try)
     die ("--userns not compatible --unshare-user-try");
 
+  if (opt_disable_userns && !opt_unshare_user)
+    die ("--disable-userns requires --unshare-user");
+
+  if (opt_disable_userns && opt_userns_block_fd != -1)
+    die ("--disable-userns is not compatible with  --userns-block-fd");
+
   /* Technically using setns() is probably safe even in the privileged
    * case, because we got passed in a file descriptor to the
    * namespace, and that can only be gotten if you have ptrace
@@ -3155,19 +3167,49 @@ main (int    argc,
   if (opt_userns2_fd > 0 && setns (opt_userns2_fd, CLONE_NEWUSER) != 0)
     die_with_error ("Setting userns2 failed");
 
-  if (opt_unshare_user &&
-      (ns_uid != opt_sandbox_uid || ns_gid != opt_sandbox_gid) &&
-      opt_userns_block_fd == -1)
+  if (opt_unshare_user && opt_userns_block_fd == -1 &&
+      (ns_uid != opt_sandbox_uid || ns_gid != opt_sandbox_gid ||
+       opt_disable_userns))
     {
-      /* Now that devpts is mounted and we've no need for mount
-         permissions we can create a new userspace and map our uid
-         1:1 */
+      /* Here we create a second level userns inside the first one. This is
+         used for one or more of these reasons:
+
+         * The 1st level namespace has a different uid/gid than the
+           requested due to requirements of beeing root in the first
+           level due for mounting devpts (opt_needs_devpts).
+
+         * To disable user namespaces we set max_user_namespaces and then
+           create the second namespace so that the sandbox cannot undo this
+           change.
+      */
+
+      if (opt_disable_userns)
+        {
+          cleanup_fd int sysctl_fd = -1;
+
+          sysctl_fd = openat (proc_fd, "sys/user/max_user_namespaces", O_WRONLY);
+
+          if (sysctl_fd < 0)
+            die_with_error ("cannot open /proc/sys/user/max_user_namespaces");
+
+          if (write_to_fd (sysctl_fd, "1", 1) < 0)
+            die_with_error ("sysctl user.max_user_namespaces = 1");
+        }
 
       if (unshare (CLONE_NEWUSER))
         die_with_error ("unshare user ns");
 
       /* We're in a new user namespace, we got back the bounding set, clear it again */
       drop_cap_bounding_set (FALSE);
+
+      if (opt_disable_userns)
+        {
+          /* Verify that we can't make a new userns again */
+          res = unshare (CLONE_NEWUSER);
+
+          if (res == 0)
+            die ("unable to disable creation of new user namespaces");
+        }
 
       write_uid_gid_map (opt_sandbox_uid, ns_uid,
                          opt_sandbox_gid, ns_gid,

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -159,6 +159,17 @@
       </para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--assert-userns-disabled</option></term>
+      <listitem><para>
+        Confirm that the process in the sandbox has been prevented from
+        creating further user namespaces, but without taking any particular
+        action to prevent that. For example, this can be combined with
+        <option>--userns</option> to check that the given user namespace
+        has already been set up to prevent the creation of further user
+        namespaces.
+      </para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--pidns <arg choice="plain">FD</arg></option></term>
       <listitem><para>Use an existing pid namespace instead of creating one. This is often used with --userns, because the pid namespace must be owned by the same user namespace that bwrap uses. </para>
       <para>Note that this can be combined with --unshare-pid, and in that case it means that the sandbox will be in its own pid namespace, which is a child of the passed in one.</para></listitem>

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -145,6 +145,20 @@
       <para>This is useful because sometimes bubblewrap itself creates nested user namespaces (to work around some kernel issues) and --userns2 can be used to enter these.</para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--disable-userns</option></term>
+      <listitem><para>
+        Prevent the process in the sandbox from creating further user namespaces,
+        so that it cannot rearrange the filesystem namespace or do other more
+        complex namespace modification.
+        This is currently implemented by setting the
+        <literal>user.max_user_namespaces</literal> sysctl to 1, and then
+        entering a nested user namespace which is unable to raise that limit
+        in the outer namespace.
+        This option requires <option>--unshare-user</option>, and doesn't work
+        in the setuid version of bubblewrap.
+      </para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--pidns <arg choice="plain">FD</arg></option></term>
       <listitem><para>Use an existing pid namespace instead of creating one. This is often used with --userns, because the pid namespace must be owned by the same user namespace that bwrap uses. </para>
       <para>Note that this can be combined with --unshare-pid, and in that case it means that the sandbox will be in its own pid namespace, which is a child of the passed in one.</para></listitem>

--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -10,6 +10,7 @@ _bwrap() {
 	# Please keep sorted in LC_ALL=C order
 	local boolean_options="
 		--as-pid-1
+		--assert-userns-disabled
 		--clearenv
 		--disable-userns
 		--help

--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -11,6 +11,7 @@ _bwrap() {
 	local boolean_options="
 		--as-pid-1
 		--clearenv
+		--disable-userns
 		--help
 		--new-session
 		--unshare-all

--- a/completions/zsh/_bwrap
+++ b/completions/zsh/_bwrap
@@ -27,6 +27,7 @@ _bwrap_args=(
 
     # Please sort alphabetically (in LC_ALL=C order) by option name
     '--add-seccomp-fd[Load and use seccomp rules from FD]: :_guard "[0-9]#" "file descriptor to read seccomp rules from"'
+    '--assert-userns-disabled[Fail unless further use of user namespace inside sandbox is disabled]'
     '--args[Parse NUL-separated args from FD]: :_guard "[0-9]#" "file descriptor with NUL-separated arguments"'
     '--as-pid-1[Do not install a reaper process with PID=1]'
     '--bind-try[Equal to --bind but ignores non-existent SRC]:source:_files:destination:_files'

--- a/completions/zsh/_bwrap
+++ b/completions/zsh/_bwrap
@@ -41,6 +41,7 @@ _bwrap_args=(
     '--dev-bind[Bind mount the host path SRC on DEST, allowing device access]:source:_files:destination:_files'
     '--dev[Mount new dev on DEST]:mount point for /dev:_files -/'
     "--die-with-parent[Kills with SIGKILL child process (COMMAND) when bwrap or bwrap's parent dies.]"
+    '--disable-userns[Disable further use of user namespaces inside sandbox]'
     '--exec-label[Exec label for the sandbox]:SELinux label:_selinux_contexts'
     '--file-label[File label for temporary sandbox content]:SELinux label:_selinux_contexts'
     '--gid[Custom gid in the sandbox (requires --unshare-user or --userns)]: :_guard "[0-9]#" "numeric group ID"'

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -126,10 +126,12 @@ else
     echo "ok - can pivot to new rootfs recursively"
 
     $BWRAP --dev-bind / / -- true
+    ! $BWRAP --assert-userns-disabled --dev-bind / / -- true
     $BWRAP --unshare-user --disable-userns --dev-bind / / -- true
     ! $BWRAP --unshare-user --disable-userns --dev-bind / / -- $BWRAP --dev-bind / / -- true
     $BWRAP --unshare-user --disable-userns --dev-bind / / -- sh -c "echo 2 > /proc/sys/user/max_user_namespaces || true; ! $BWRAP --dev-bind / / -- true"
     $BWRAP --unshare-user --disable-userns --dev-bind / / -- sh -c "echo 100 > /proc/sys/user/max_user_namespaces || true; ! $BWRAP --dev-bind / / -- true"
+    $BWRAP --unshare-user --disable-userns --dev-bind / / -- sh -c "! $BWRAP --dev-bind / / --assert-userns-disabled -- true"
     echo "ok - can disable nested userns"
 fi
 


### PR DESCRIPTION
* Add an option to disable nested user namespaces by setting limit to 1
    
    Some use-cases of bubblewrap want to ensure that the subprocess can't
    further re-arrange the filesystem namespace, or do other more complex
    namespace modification. For example, Flatpak wants to prevent sandboxed
    processes from altering their /proc/$pid/root/.flatpak-info, so that
    /.flatpak-info can safely be used as an indicator that a process is part
    of a Flatpak app.
    
    This approach was suggested by lukts30 on containers/bubblewrap#452.
    The sysctl-controlled maximum numbers of namespaces are themselves
    namespaced, so we can disable nested user namespaces by setting the
    limit to 1 and then entering a new, nested user namespace. The resulting
    process loses its privileges in the namespace where the limit was set
    to 1, so it is unable to move the limit back up.
    
    Co-authored-by: Alexander Larsson

* Add --assert-userns-disabled option
    
    We can't combine --disable-userns with entering an existing user
    namespace via --userns if the existing user namespace was created with
    --disable-userns, because its ability to create nested user namespaces
    has already been disabled. However, the next best thing is to verify
    that we are already in the desired state.