### PR TITLE
try-syscall: Use compiler-predefined macros to detect mips ABI

### DIFF
--- a/tests/try-syscall.c
+++ b/tests/try-syscall.c
@@ -24,11 +24,11 @@
 #include <sys/types.h>
 
 #if defined(_MIPS_SIM)
-# if _MIPS_SIM == _MIPS_SIM_ABI32
+# if _MIPS_SIM == _ABIO32
 #   define MISSING_SYSCALL_BASE 4000
-# elif _MIPS_SIM == _MIPS_SIM_ABI64
+# elif _MIPS_SIM == _ABI64
 #   define MISSING_SYSCALL_BASE 5000
-# elif _MIPS_SIM == _MIPS_SIM_NABI32
+# elif _MIPS_SIM == _ABIN32
 #   define MISSING_SYSCALL_BASE 6000
 # else
 #   error "Unknown MIPS ABI"


### PR DESCRIPTION
_MIPS_SIM_ABI32 etc. are defined by Linux <asm/sgidefs.h>, which is
included by glibc <sys/syscall.h> (which defers to Linux headers to
get syscall numbers), but not by musl <sys/syscall.h>.

_ABIO32 etc. are predefined by the compiler, so they are always
available, regardless of libc. References:

https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=27d54b2a6c18ef1ae50f1a5b432d590438445b90
https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=0ea339ea4d9c3e04ae17da6bf389617eb0251e57