### PR TITLE
meson: Allow installation directory to be set explicitly

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -101,12 +101,14 @@ configure_file(
   configuration : cdata,
 )
 
-if meson.is_subproject()
-  bwrapdir = get_option('libexecdir')
+if meson.is_subproject() and get_option('program_prefix') == ''
+  error('program_prefix option must be set when bwrap is a subproject')
+endif
 
-  if get_option('program_prefix') == ''
-    error('program_prefix option must be set when bwrap is a subproject')
-  endif
+if get_option('bwrapdir') != ''
+  bwrapdir = get_option('bwrapdir')
+elif meson.is_subproject()
+  bwrapdir = get_option('libexecdir')
 else
   bwrapdir = get_option('bindir')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -11,6 +11,11 @@ option(
   value : '',
 )
 option(
+  'bwrapdir',
+  type : 'string',
+  description : 'install bwrap in this directory [default: bindir, or libexecdir in subprojects]',
+)
+option(
   'man',
   type : 'feature',
   description : 'generate man pages',


### PR DESCRIPTION
Overriding the libexecdir via default_options doesn't always work when
used as a subproject.