### PR TITLE
meson: Add options to set a RPATH/RUNPATH on the bwrap executable

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -127,6 +127,7 @@ jobs:
         test -x DESTDIR-as-subproject/usr/local/libexec/not-flatpak-bwrap
         test ! -e DESTDIR-as-subproject/usr/local/bin/bwrap
         test ! -e DESTDIR-as-subproject/usr/local/libexec/bwrap
+        tests/use-as-subproject/assert-correct-rpath.py DESTDIR-as-subproject/usr/local/libexec/not-flatpak-bwrap
     - name: Upload test logs
       uses: actions/upload-artifact@v1
       if: failure() || cancelled()

--- a/meson.build
+++ b/meson.build
@@ -121,8 +121,10 @@ bwrap = executable(
     'network.c',
     'utils.c',
   ],
+  build_rpath : get_option('build_rpath'),
   install : true,
   install_dir : bwrapdir,
+  install_rpath : get_option('install_rpath'),
   dependencies : [selinux_dep, libcap_dep],
 )
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,6 +16,16 @@ option(
   description : 'install bwrap in this directory [default: bindir, or libexecdir in subprojects]',
 )
 option(
+  'build_rpath',
+  type : 'string',
+  description : 'set a RUNPATH or RPATH on the bwrap executable',
+)
+option(
+  'install_rpath',
+  type : 'string',
+  description : 'set a RUNPATH or RPATH on the bwrap executable',
+)
+option(
   'man',
   type : 'feature',
   description : 'generate man pages',

--- a/tests/use-as-subproject/assert-correct-rpath.py
+++ b/tests/use-as-subproject/assert-correct-rpath.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+# Copyright 2022 Collabora Ltd.
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+import subprocess
+import sys
+
+if __name__ == '__main__':
+    completed = subprocess.run(
+        ['objdump', '-T', '-x', sys.argv[1]],
+        stdout=subprocess.PIPE,
+    )
+    stdout = completed.stdout
+    assert stdout is not None
+    seen_rpath = False
+
+    for line in stdout.splitlines():
+        words = line.strip().split()
+
+        if words and words[0] in (b'RPATH', b'RUNPATH'):
+            print(line.decode(errors='backslashreplace'))
+            assert len(words) == 2, words
+            assert words[1] == b'${ORIGIN}/../lib', words
+            seen_rpath = True
+
+    assert seen_rpath

--- a/tests/use-as-subproject/meson.build
+++ b/tests/use-as-subproject/meson.build
@@ -14,6 +14,7 @@ configure_file(
 subproject(
   'bubblewrap',
   default_options : [
+    'install_rpath=${ORIGIN}/../lib',
     'program_prefix=not-flatpak-',
   ],
 )


### PR DESCRIPTION
This is useful when building a self-contained, relocatable tree
containing a build of bubblewrap and all of its non-glibc dependencies
(in practice this means libcap and maybe libselinux), as is done in
the Steam container runtime. A RPATH/RUNPATH pointing to ${ORIGIN}/../lib
allows bwrap to find an adjacent, bundled copy of libcap.