### PR TITLE
Allow building on old glibc without PR_SET_CHILD_SUBREAPER defined

### DIFF
--- a/tests/try-syscall.c
+++ b/tests/try-syscall.c
@@ -71,6 +71,10 @@
  */
 #define WRONG_POINTER ((char *) 1)
 
+#ifndef PR_GET_CHILD_SUBREAPER
+#define PR_GET_CHILD_SUBREAPER 37
+#endif
+
 int
 main (int argc, char **argv)
 {

--- a/utils.h
+++ b/utils.h
@@ -48,6 +48,10 @@ typedef int bool;
 #define PIPE_READ_END 0
 #define PIPE_WRITE_END 1
 
+#ifndef PR_SET_CHILD_SUBREAPER
+#define PR_SET_CHILD_SUBREAPER 36
+#endif
+
 void  warn (const char *format,
             ...) __attribute__((format (printf, 1, 2)));
 void  die_with_error (const char *format,


### PR DESCRIPTION
This change would be useful for the [Steam container runtime](https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/master/docs/container-runtime.md), to avoid having to patch the bundled copy of bubblewrap to be able to use it as a subproject.