### PR TITLE
build: Auto-detect presence of Docbook XSL stylesheets

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -124,9 +124,24 @@ bwrap = executable(
   dependencies : [selinux_dep, libcap_dep],
 )
 
+manpages_xsl = 'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl'
 xsltproc = find_program('xsltproc', required : get_option('man'))
+build_man_page = false
 
 if xsltproc.found() and not meson.is_subproject()
+  if run_command([
+    xsltproc, '--nonet', manpages_xsl,
+  ], check : false).returncode() == 0
+    message('Docbook XSL found, man page enabled')
+    build_man_page = true
+  elif get_option('man').enabled()
+    error('Man page requested, but Docbook XSL stylesheets not found')
+  else
+    message('Docbook XSL not found, man page disabled automatically')
+  endif
+endif
+
+if build_man_page
   custom_target(
     'bwrap.1',
     output : 'bwrap.1',
@@ -140,7 +155,7 @@ if xsltproc.found() and not meson.is_subproject()
       '--stringparam', 'man.authors.section.enabled', '0',
       '--stringparam', 'man.copyright.section.enabled', '0',
       '-o', '@OUTPUT@',
-      'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl',
+      manpages_xsl,
       '@INPUT@',
     ],
     install : true,


### PR DESCRIPTION
This follows the usual feature semantics: they're mandatory if the
feature is enabled, aren't checked if the feature is disabled, and are
optional if the feature is in the auto state (which is the default for
this particular feature).

The logic used here is similar to AX_CHECK_DOCBOOK_XSLT in
autoconf-archive.

Resolves: https://github.com/containers/bubblewrap/issues/500
