### PR TITLE
tests: Better compatibility with gcc/clang sanitizers

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -110,7 +110,7 @@ jobs:
         ( cd DESTDIR && find -ls )
     - name: dist
       run: |
-        BWRAP_MUST_WORK=1 CI_MESON_DIST=1 meson dist -C _build
+        BWRAP_MUST_WORK=1 meson dist -C _build
     - name: Collect dist test logs on failure
       if: failure()
       run: mv _build/meson-private/dist-build/meson-logs/testlog.txt test-logs/disttestlog.txt || true

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -12,6 +12,7 @@ test_programs = [
 executable(
   'try-syscall',
   'try-syscall.c',
+  override_options: ['b_sanitize=none'],
 )
 
 test_scripts = [

--- a/tests/test-specifying-pidns.sh
+++ b/tests/test-specifying-pidns.sh
@@ -10,14 +10,13 @@ echo "1..1"
 # This test needs user namespaces
 if test -n "${bwrap_is_suid:-}"; then
     echo "ok - # SKIP no setuid support for --unshare-user"
-elif test -n "${CI_MESON_DIST:-}"; then
-    echo "not ok - # TODO this test hangs under 'meson dist' during Github Workflow CI"
 else
     mkfifo donepipe
     $RUN --info-fd 42 --unshare-user --unshare-pid sh -c 'readlink /proc/self/ns/pid > sandbox-pidns; cat < donepipe' >/dev/null 42>info.json &
     while ! test -f sandbox-pidns; do sleep 1; done
     SANDBOX1PID=$(extract_child_pid info.json)
 
+    ASAN_OPTIONS=detect_leaks=0 LSAN_OPTIONS=detect_leaks=0 \
     $RUN --userns 11 --pidns 12 readlink /proc/self/ns/pid > sandbox2-pidns 11< /proc/$SANDBOX1PID/ns/user 12< /proc/$SANDBOX1PID/ns/pid
     echo foo > donepipe
 


### PR DESCRIPTION
* tests: Disable sanitizers for try-syscall
    
    gcc's AddressSanitizer makes system calls that our filter doesn't
    allow for, resulting in a fatal error when run under a restrictive
    seccomp filter.
    
    try-syscall is a helper for the test, rather than being code under test
    itself, so we don't really need this instrumentation in it: all we want
    it to do is make some specific syscalls.

* tests: Disable leak detection when joining user-specified pid namespace
    
    If we don't do this, AddressSanitizer busy-loops with this backtrace:
    
        #0  in sched_yield
        #1  in __sanitizer::StopTheWorld
        #2  in __lsan::LockStuffAndStopTheWorldCallback
        #3  in __GI___dl_iterate_phdr
        #4  in __lsan::LockStuffAndStopTheWorld
        #5  in __lsan::CheckForLeaks
        #6  in __lsan::DoLeakCheck
        #7  __lsan::DoLeakCheck
        #8  in __cxa_finalize
        #9  in __do_global_dtors_aux
        #10 in ??
        #11 in _dl_fini

    This fixes the hang described in commit 2e3d6e7d, so remove the
    workarounds from that commit.

---

Desirable for https://github.com/flatpak/flatpak/pull/4845