### PR TITLE
Add --size option to control size of a --tmpfs

### DIFF
--- a/bwrap.xml
+++ b/bwrap.xml
@@ -207,6 +207,9 @@
     (rwxr-xr-x). However, if a <option>--perms</option> option is in effect, and
     it sets the permissions for group or other to zero, then newly-created
     parent directories will also have their corresponding permission set to zero.
+    <option>--size</option> modifies the size of the created mount when preceding a
+    <option>--tmpfs</option> action; <option>--perms</option> and <option>--size</option>
+    can be combined.
   </para>
   <variablelist>
     <varlistentry>
@@ -217,7 +220,24 @@
         Subsequent operations are not affected: for example,
         <literal>--perms 0700 --tmpfs /a --tmpfs /b</literal> will mount
         <filename>/a</filename> with permissions 0700, then return to
-        the default permissions for <filename>/b</filename>.</para></listitem>
+        the default permissions for <filename>/b</filename>.
+        Note that <option>--perms</option> and <option>--size</option> can be
+        combined: <literal>--perms 0700 --size 10485760 --tmpfs /s</literal> will apply
+        permissions as well as a maximum size to the created tmpfs.</para></listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><option>--size <arg choice="plain">BYTES</arg></option></term>
+      <listitem><para>This option does nothing on its own, and must be followed
+        by <literal>--tmpfs</literal>. It sets the size in bytes for the next tmpfs.
+        For example, <literal>--size 10485760 --tmpfs /tmp</literal> will create a tmpfs
+        at <filename>/tmp</filename> of size 10MiB. Subsequent operations are not
+        affected: for example,
+        <literal>--size 10485760 --tmpfs /a --tmpfs /b</literal> will mount
+        <filename>/a</filename> with size 10MiB, then return to the default size for
+        <filename>/b</filename>.
+        Note that <option>--perms</option> and <option>--size</option> can be
+        combined: <literal>--size 10485760 --perms 0700 --tmpfs /s</literal> will apply
+        permissions as well as a maximum size to the created tmpfs.</para></listitem>
     </varlistentry>
     <varlistentry>
       <term><option>--bind <arg choice="plain">SRC</arg> <arg choice="plain">DEST</arg></option></term>
@@ -260,7 +280,9 @@
       <listitem>
         <para>Mount new tmpfs on <arg choice="plain">DEST</arg>.
           If the previous option was <option>--perms</option>, it sets the
-          mode of the tmpfs. Otherwise, the tmpfs has mode 0755.</para>
+          mode of the tmpfs. Otherwise, the tmpfs has mode 0755.
+          If the previous option was <option>--size</option>, it sets the
+          size in bytes of the tmpfs. Otherwise, the tmpfs has the default size.</para>
       </listitem>
     </varlistentry>
     <varlistentry>

--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -54,6 +54,7 @@ _bwrap() {
 		--ro-bind
 		--seccomp
 		--setenv
+		--size
 		--symlink
 		--sync-fd
 		--uid

--- a/completions/zsh/_bwrap
+++ b/completions/zsh/_bwrap
@@ -1,11 +1,23 @@
 #compdef bwrap
 
+_bwrap_args_after_perms_size=(
+    # Please sort alphabetically (in LC_ALL=C order) by option name
+    '--tmpfs[Mount new tmpfs on DEST]:mount point for tmpfs:_files -/'
+)
+
 _bwrap_args_after_perms=(
     # Please sort alphabetically (in LC_ALL=C order) by option name
     '--bind-data[Copy from FD to file which is bind-mounted on DEST]: :_guard "[0-9]#" "file descriptor to read content":destination:_files'
     '--dir[Create dir at DEST]:directory to create:_files -/'
     '--file[Copy from FD to destination DEST]: :_guard "[0-9]#" "file descriptor to read content from":destination:_files'
     '--ro-bind-data[Copy from FD to file which is readonly bind-mounted on DEST]: :_guard "[0-9]#" "file descriptor to read content from":destination:_files'
+    '--size[Set size in bytes for next action argument]: :->after_perms_size'
+    '--tmpfs[Mount new tmpfs on DEST]:mount point for tmpfs:_files -/'
+)
+
+_bwrap_args_after_size=(
+    # Please sort alphabetically (in LC_ALL=C order) by option name
+    '--perms[Set permissions for next action argument]: :_guard "[0-7]#" "permissions in octal": :->after_perms_size'
     '--tmpfs[Mount new tmpfs on DEST]:mount point for tmpfs:_files -/'
 )
 
@@ -47,6 +59,7 @@ _bwrap_args=(
     '--ro-bind[Bind mount the host path SRC readonly on DEST]:source:_files:destination:_files'
     '--seccomp[Load and use seccomp rules from FD]: :_guard "[0-9]#" "file descriptor to read seccomp rules from"'
     '--setenv[Set an environment variable]:variable to set:_parameters -g "*export*":value of variable: :'
+    '--size[Set size in bytes for next action argument]: :->after_size'
     '--symlink[Create symlink at DEST with target SRC]:symlink target:_files:symlink to create:_files:'
     '--sync-fd[Keep this fd open while sandbox is running]: :_guard "[0-9]#" "file descriptor to keep open"'
     '--uid[Custom uid in the sandbox (requires --unshare-user or --userns)]: :_guard "[0-9]#" "numeric group ID"'
@@ -71,6 +84,14 @@ _bwrap() {
     case "$state" in
         after_perms)
             _values -S ' ' 'option' $_bwrap_args_after_perms
+            ;;
+
+        after_size)
+            _values -S ' ' 'option' $_bwrap_args_after_size
+            ;;
+
+        after_perms_size)
+            _values -S ' ' 'option' $_bwrap_args_after_perms_size
             ;;
 
         caps)

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -8,7 +8,7 @@ srcd=$(cd $(dirname "$0") && pwd)
 
 bn=$(basename "$0")
 
-echo "1..54"
+echo "1..57"
 
 # Test help
 ${BWRAP} --help > help.txt
@@ -398,6 +398,29 @@ $RUN \
 assert_file_has_content dir-permissions '^755$'
 echo "ok - tmpfs has expected permissions"
 
+# 1048576 = 1 MiB
+$RUN \
+    --size 1048576 --tmpfs "$(pwd -P)" \
+    df --output=size --block-size=1K "$(pwd -P)" > dir-size
+assert_file_has_content dir-size '^ *1024$'
+$RUN \
+    --size 1048576 --perms 01777 --tmpfs "$(pwd -P)" \
+    stat -c '%a' "$(pwd -P)" > dir-permissions
+assert_file_has_content dir-permissions '^1777$'
+$RUN \
+    --size 1048576 --perms 01777 --tmpfs "$(pwd -P)" \
+    df --output=size --block-size=1K "$(pwd -P)" > dir-size
+assert_file_has_content dir-size '^ *1024$'
+$RUN \
+    --perms 01777 --size 1048576 --tmpfs "$(pwd -P)" \
+    stat -c '%a' "$(pwd -P)" > dir-permissions
+assert_file_has_content dir-permissions '^1777$'
+$RUN \
+    --perms 01777 --size 1048576 --tmpfs "$(pwd -P)" \
+    df --output=size --block-size=1K "$(pwd -P)" > dir-size
+assert_file_has_content dir-size '^ *1024$'
+echo "ok - tmpfs has expected size"
+
 $RUN \
     --file 0 /tmp/file \
     stat -c '%a' /tmp/file < /dev/null > file-permissions
@@ -423,6 +446,40 @@ $RUN \
     stat -c '%a' /tmp/file < /dev/null > file-permissions
 assert_file_has_content file-permissions '^640$'
 echo "ok - files have expected permissions"
+
+if $RUN --size 0 --tmpfs /tmp/a true; then
+    assert_not_reached Zero tmpfs size allowed
+fi
+if $RUN --size 123bogus --tmpfs /tmp/a true; then
+    assert_not_reached Bogus tmpfs size allowed
+fi
+if $RUN --size '' --tmpfs /tmp/a true; then
+    assert_not_reached Empty tmpfs size allowed
+fi
+if $RUN --size -12345678 --tmpfs /tmp/a true; then
+    assert_not_reached Negative tmpfs size allowed
+fi
+if $RUN --size ' -12345678' --tmpfs /tmp/a true; then
+    assert_not_reached Negative tmpfs size with space allowed
+fi
+# This is 2^64
+if $RUN --size 18446744073709551616 --tmpfs /tmp/a true; then
+    assert_not_reached Overflowing tmpfs size allowed
+fi
+# This is 2^63 + 1; note that the current max size is SIZE_MAX/2
+if $RUN --size 9223372036854775809 --tmpfs /tmp/a true; then
+    assert_not_reached Too-large tmpfs size allowed
+fi
+echo "ok - bogus tmpfs size not allowed"
+
+if $RUN --perms 0640 --perms 0640 --tmpfs /tmp/a true; then
+    assert_not_reached Multiple perms options allowed
+fi
+if $RUN --size 1048576 --size 1048576 --tmpfs /tmp/a true; then
+    assert_not_reached Multiple perms options allowed
+fi
+echo "ok - --perms and --size only allowed once"
+
 
 FOO= BAR=baz $RUN --setenv FOO bar sh -c 'echo "$FOO$BAR"' > stdout
 assert_file_has_content stdout barbaz


### PR DESCRIPTION
## Rationale

`bwrap` is a sandboxing utility, and one usually sandboxes a process to control its access to resources. One of the resources that one might want to control is disk space usage, but `bwrap` currently provides no facilities to control disk space usage.

We're using `bwrap` for [a programming language playground](https://github.com/tomsmeding/pastebin-haskell/tree/play) where people can submit arbitrary code; we run the code on a server and send the output back. Obviously this needs sandboxing, and among other things, we want to avoid an ENOSPC DOS.

#375 suggested a possible fix for this missing feature: to add a facility to control the size of a created `tmpfs`.

Fixes #375.

## Solution

This adds a new `--size` option that works similarly to `--perms` in that it modifies a subsequent `--tmpfs` option. Like `--perms`, an error is thrown if the option is not applied to a suitable action; `--size` is currently only implemented for `--tmpfs`. Combining `--perms` and `--size` is allowed, and the code checks that the options are not given twice for the same action.

~~The argument to the `--size` option is checked for acceptability (namely being fully alphanumeric, so that it does not escape the `size=` mount option of tmpfs) in the privileged process that receives privileged-operation requests; this is not done earlier because we need to do it here anyway, due to the untrustedness of the unprivileged code.~~ (made obsolete due to accepting a number of bytes)

## Review

Please review this code! I'm not familiar with the bwrap codebase, hence I probably made mistakes. Tests have been added (and they pass) and documentation has been updated, but I didn't build the documentation locally to see if the result is good.