### PR TITLE
Adjust tests related to /etc/shadow

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -40,9 +40,15 @@ for ALT in "" "--unshare-user-try" "--unshare-pid" "--unshare-user-try --unshare
     fi
 
     if ! cat /etc/shadow >/dev/null &&
+        $RUN $CAP $ALT --unshare-net --proc /proc --bind /etc/shadow /tmp/foo cat /tmp/foo; then
+        assert_not_reached Could read /etc/shadow via /tmp/foo bind-mount
+    fi
+
+    if ! cat /etc/shadow >/dev/null &&
         $RUN $CAP $ALT --unshare-net --proc /proc --bind /etc/shadow /tmp/foo cat /etc/shadow; then
         assert_not_reached Could read /etc/shadow
     fi
+
     echo "ok - cannot read /etc/shadow with $ALT"
     # Unreadable dir
     if [ "x$UNREADABLE" != "x" ]; then

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -39,7 +39,8 @@ for ALT in "" "--unshare-user-try" "--unshare-pid" "--unshare-user-try --unshare
         CAP=""
     fi
 
-    if ! ${is_uidzero} && $RUN $CAP $ALT --unshare-net --proc /proc --bind /etc/shadow /tmp/foo cat /etc/shadow; then
+    if ! cat /etc/shadow >/dev/null &&
+        $RUN $CAP $ALT --unshare-net --proc /proc --bind /etc/shadow /tmp/foo cat /etc/shadow; then
         assert_not_reached Could read /etc/shadow
     fi
     echo "ok - cannot read /etc/shadow with $ALT"


### PR DESCRIPTION
* test-run: Skip a test if we can read /etc/shadow
    
    Ordinarily, we would not be able to read /etc/shadow if we're not uid 0;
    but when building in a sysroot owned by the current user (for example
    by setting it up using bwrap, as steam-runtime-tools does), we might
    actually be able to read it. Skip the assertion that we cannot read it
    in this case.

* test-run: Add another assertion that we cannot read /etc/shadow
    
    The goal of this assertion was to demonstrate that a setuid bwrap does
    not give us access to otherwise unreadable files, but if we want to
    check that, we should probably be looking at the bind-mount destination
    instead of the source file.
    
    Leave the old assertion in too, just in case *that* fails.

---

@RyuzakiKK will probably find this useful.