### PR TITLE
Fix test failures in 0.7.0 on unusual platforms

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -411,7 +411,7 @@ if test -n "${bwrap_is_suid:-}"; then
         assert_not_reached "Should not allow --size --tmpfs when setuid"
     fi
     echo "ok - --size --tmpfs is not allowed when setuid"
-else
+elif df --output=size --block-size=1K "$(pwd -P)" >/dev/null 2>/dev/null; then
     $RUN \
         --size 1048576 --tmpfs "$(pwd -P)" \
         df --output=size --block-size=1K "$(pwd -P)" > dir-size
@@ -433,6 +433,11 @@ else
         df --output=size --block-size=1K "$(pwd -P)" > dir-size
     assert_file_has_content dir-size '^ *1024$'
     echo "ok - tmpfs has expected size"
+else
+    $RUN --size 1048576 --tmpfs "$(pwd -P)" true
+    $RUN --perms 01777 --size 1048576 --tmpfs "$(pwd -P)" true
+    $RUN --size 1048576 --perms 01777 --tmpfs "$(pwd -P)" true
+    echo "ok # SKIP df is too old, cannot test --size --tmpfs fully"
 fi
 
 $RUN \


### PR DESCRIPTION
* test-run: If bubblewrap is setuid, assert that --size is not allowed
    
    Previously, this test would have failed for a setuid bubblewrap.

* test-run: Don't rely on df supporting the --output=size option
    
    df --output was new in coreutils 8.21 (2013), and non-GNU
    implementations like busybox df don't have it.
    
    This avoids a test failure in Steam Runtime 1 'scout', which is based
    on Ubuntu 12.04 (2012). It'll also be helpful for anyone maintaining
    an OS with non-GNU shell utilities.

cc @RyuzakiKK @tomsmeding 