### PR TITLE
test-run: Filter out no-new-privs in capsh output

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -143,10 +143,11 @@ if ! ${is_uidzero}; then
     done
     echo "ok - we have no caps as uid != 0"
 else
-    capsh --print > caps.orig
+    capsh --print | sed -e 's/no-new-privs=0/no-new-privs=1/' > caps.expected
+
     for OPT in "" "--as-pid-1"; do
         $RUN $OPT --unshare-pid capsh --print >caps.test
-        diff -u caps.orig caps.test
+        diff -u caps.expected caps.test
     done
     # And test that we can drop all, as well as specific caps
     $RUN $OPT --cap-drop ALL --unshare-pid capsh --print >caps.test


### PR DESCRIPTION
Older versions of capsh would only show the capabilities, which we expect not to change when we don't drop capabilities; but newer versions also display whether the NO_NEW_PRIVS bit is set, and we *do* expect to change that.

Resolves: https://github.com/containers/bubblewrap/issues/544