### PR TITLE
Add --overlay and related options

### DIFF
--- a/bwrap.xml
+++ b/bwrap.xml
@@ -318,6 +318,86 @@
       <listitem><para>Remount the path <arg choice="plain">DEST</arg> as readonly.  It works only on the specified mount point, without changing any other mount point under the specified path</para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--overlay-src <arg choice="plain">SRC</arg></option></term>
+      <listitem>
+        <para>
+          This option does nothing on its own, and must be followed by one of
+          the other <literal>overlay</literal> options. It specifies a host
+          path from which files should be read if they aren't present in a
+          higher layer.
+        </para>
+        <para>
+          This option can be used multiple times to provide multiple sources.
+          The sources are overlaid in the order given, with the first source on
+          the command line at the bottom of the stack: if a given path to be
+          read exists in more than one source, the file is read from the last
+          such source specified.
+        </para>
+        <para>
+          (For readers familiar with overlayfs, note that this is the
+          reverse of the order used by the kernel's <literal>lowerdir</literal>
+          mount option.)
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><option>--overlay <arg choice="plain">RWSRC</arg> <arg choice="plain">WORKDIR</arg> <arg choice="plain">DEST</arg></option></term>
+    </varlistentry>
+    <varlistentry>
+      <term><option>--tmp-overlay <arg choice="plain">DEST</arg></option></term>
+    </varlistentry>
+    <varlistentry>
+      <term><option>--ro-overlay <arg choice="plain">DEST</arg></option></term>
+      <listitem>
+        <para>
+          Use overlayfs to mount the host paths specified by
+          <arg choice="plain">RWSRC</arg> and all immediately preceding
+          <option>--overlay-src</option> on <arg choice="plain">DEST</arg>.
+          <arg choice="plain">DEST</arg> will contain the union of all the files
+          in all the layers.
+        </para>
+        <para>
+          With <arg choice="plain">--overlay</arg> all writes will go to
+          <arg choice="plain">RWSRC</arg>. Reads will come preferentially from
+          <arg choice="plain">RWSRC</arg>, and then from any
+          <option>--overlay-src</option> paths.
+          <arg choice="plain">WORKDIR</arg> must be an empty directory on the
+          same filesystem as <arg choice="plain">RWSRC</arg>, and is used
+          internally by the kernel.
+        </para>
+        <para>
+          With <arg choice="plain">--tmp-overlay</arg> all writes will go to
+          the tmpfs that hosts the sandbox root, in a location not accessible
+          from either the host or the child process. Writes will therefore not
+          be persisted across multiple runs.
+        </para>
+        <para>
+          With <arg choice="plain">--ro-overlay</arg> the filesystem will be
+          mounted read-only. This option requires at least two
+          <option>--overlay-src</option> to precede it.
+        </para>
+        <para>
+          None of these options are available in the setuid version of
+          bubblewrap. Using <arg choice="plain">--ro-overlay</arg> or providing
+          more than one <option>--overlay-src</option> requires a Linux kernel
+          version of 4.0 or later.
+        </para>
+        <para>
+          Due to limitations of overlayfs, no host directory given via
+          <arg choice="plain">--overlay-src</arg> or
+          <arg choice="plain">--overlay</arg> may be an ancestor of another,
+          after resolving symlinks. Depending on version, the Linux kernel may
+          or may not enforce this, but if not then overlayfs's behavior is
+          undefined.
+        </para>
+        <para>
+          For more information see the Overlay Filesystem documentation in the
+          Linux kernel at
+          https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--proc <arg choice="plain">DEST</arg></option></term>
       <listitem><para>Mount procfs on <arg choice="plain">DEST</arg></para></listitem>
     </varlistentry>

--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -51,15 +51,19 @@ _bwrap() {
 		--hostname
 		--info-fd
 		--lock-file
+		--overlay
+		--overlay-src
 		--perms
 		--proc
 		--remount-ro
 		--ro-bind
+		--ro-overlay
 		--seccomp
 		--setenv
 		--size
 		--symlink
 		--sync-fd
+		--tmp-overlay
 		--uid
 		--unsetenv
 		--userns-block-fd

--- a/tests/test-utils.c
+++ b/tests/test-utils.c
@@ -200,6 +200,37 @@ test_has_path_prefix (void)
     }
 }
 
+static void
+test_string_builder (void)
+{
+  StringBuilder sb = {0};
+
+  strappend (&sb, "aaa");
+  g_assert_cmpstr (sb.str, ==, "aaa");
+  strappend (&sb, "bbb");
+  g_assert_cmpstr (sb.str, ==, "aaabbb");
+  strappendf (&sb, "c%dc%s", 9, "x");
+  g_assert_cmpstr (sb.str, ==, "aaabbbc9cx");
+  strappend_escape_for_mount_options (&sb, "/path :,\\");
+  g_assert_cmpstr (sb.str, ==, "aaabbbc9cx/path \\:\\,\\\\");
+  strappend (&sb, "zzz");
+  g_assert_cmpstr (sb.str, ==, "aaabbbc9cx/path \\:\\,\\\\zzz");
+
+  free (sb.str);
+  sb = (StringBuilder){0};
+
+  strappend_escape_for_mount_options (&sb, "aaa");
+  g_assert_cmpstr (sb.str, ==, "aaa");
+
+  free (sb.str);
+  sb = (StringBuilder){0};
+
+  strappend_escape_for_mount_options (&sb, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  g_assert_cmpstr (sb.str, ==, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+  free (sb.str);
+}
+
 int
 main (int argc UNUSED,
       char **argv UNUSED)
@@ -210,6 +241,7 @@ main (int argc UNUSED,
   test_strconcat3 ();
   test_has_prefix ();
   test_has_path_prefix ();
+  test_string_builder ();
   printf ("1..%u\n", test_number);
   return 0;
 }

--- a/utils.h
+++ b/utils.h
@@ -198,3 +198,20 @@ steal_pointer (void *pp)
 /* type safety */
 #define steal_pointer(pp) \
   (0 ? (*(pp)) : (steal_pointer) (pp))
+
+typedef struct _StringBuilder StringBuilder;
+
+struct _StringBuilder
+{
+  char * str;
+  size_t size;
+  size_t offset;
+};
+
+void strappend (StringBuilder *dest,
+                const char    *src);
+void strappendf (StringBuilder *dest,
+                 const char    *fmt,
+                 ...);
+void strappend_escape_for_mount_options (StringBuilder *dest,
+                                         const char    *src);


### PR DESCRIPTION
This commit adds --overlay, --tmp-overlay, --ro-overlay, and --overlay-src options to enable bubblewrap to create overlay mounts. These options are only permitted when bubblewrap is not installed setuid.

---

This is a continuation/partial rewrite of #167, addressing the feedback given there.

Other improvements of note:
* Tests!
* Characters treated specially by overlayfs are escaped; there are now no (known?) restrictions on the characters that can be in an overlay path.
*  `--tmp-overlay` is a new contribution for a use case I frequently have: I want to mount an overlay that is writable but I don't want to persist the writes between runs.