### PR TITLE
Update bwrap.xml: Indicate potential problem forking mountspaces may cause.

### DIFF
--- a/bwrap.xml
+++ b/bwrap.xml
@@ -54,6 +54,7 @@
 </para>
 <para>
   By default, <command>bwrap</command> creates a new mount namespace for the sandbox.
+  Be aware that this may interfere with attempts to close mapped devices such as encrypted drives.
   Optionally it also sets up new user, ipc, pid, network and uts namespaces (but note the
   user namespace is required if bwrap is not installed setuid root).
   The application in the sandbox can be made to run with a different UID and GID.


### PR DESCRIPTION
The only indication that this may occur is the timing of lsof return - with every instance of bubblewrap closed, return was a bit faster. Problem referenced: https://forums.gentoo.org/viewtopic-t-1116050-start-0.html

```When a mount namespace is forked from its parent, it inherits all existing mounts. When you ran umount, you only unmounted in the namespace where you ran that. The device remains mounted in any other mount namespaces where it was mounted, preventing you from closing the device.```


Nothing indicated why a mapped device was busy when attempting to close.