### PR TITLE
Attempt to clarify error message for missing CONFIG_SECCOMP_FILTER

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -288,7 +288,15 @@ seccomp_programs_apply (void)
   for (program = seccomp_programs; program != NULL; program = program->next)
     {
       if (prctl (PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &program->program) != 0)
-        die_with_error ("prctl(PR_SET_SECCOMP)");
+        {
+          if (errno == EINVAL)
+            die ("Unable to set up system call filtering as requested: "
+                 "prctl(PR_SET_SECCOMP) reported EINVAL. "
+                 "(Hint: this requires a kernel configured with "
+                 "CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER.)");
+
+          die_with_error ("prctl(PR_SET_SECCOMP)");
+        }
     }
 }
 


### PR DESCRIPTION
General-purpose desktop distributions are compiled with CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER, but vendor kernels for phones and other assorted embedded devices don't necessarily enable these options. These kernels are unsuitable for running Flatpak, or anything else that relies on `bwrap --seccomp` or `bwrap --add-seccomp-fd`.

Missing CONFIG_SECCOMP or CONFIG_SECCOMP_FILTER is not the *only* reason why we could get EINVAL here: I think we'd also get EINVAL if the seccomp program is syntatically invalid. However, it's a relatively likely reason, so it seems worth providing a hint.

Helps: flatpak/flatpak#3069