### PR TITLE
Fix test failure since #488 when running as uid 0

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -129,9 +129,9 @@ else
     ! $BWRAP --assert-userns-disabled --dev-bind / / -- true
     $BWRAP --unshare-user --disable-userns --dev-bind / / -- true
     ! $BWRAP --unshare-user --disable-userns --dev-bind / / -- $BWRAP --dev-bind / / -- true
-    $BWRAP --unshare-user --disable-userns --dev-bind / / -- sh -c "echo 2 > /proc/sys/user/max_user_namespaces || true; ! $BWRAP --dev-bind / / -- true"
-    $BWRAP --unshare-user --disable-userns --dev-bind / / -- sh -c "echo 100 > /proc/sys/user/max_user_namespaces || true; ! $BWRAP --dev-bind / / -- true"
-    $BWRAP --unshare-user --disable-userns --dev-bind / / -- sh -c "! $BWRAP --dev-bind / / --assert-userns-disabled -- true"
+    $BWRAP --unshare-user --disable-userns --dev-bind / / -- sh -c "echo 2 > /proc/sys/user/max_user_namespaces || true; ! $BWRAP --unshare-user --dev-bind / / -- true"
+    $BWRAP --unshare-user --disable-userns --dev-bind / / -- sh -c "echo 100 > /proc/sys/user/max_user_namespaces || true; ! $BWRAP --unshare-user --dev-bind / / -- true"
+    $BWRAP --unshare-user --disable-userns --dev-bind / / -- sh -c "! $BWRAP --unshare-user --dev-bind / / --assert-userns-disabled -- true"
     echo "ok - can disable nested userns"
 fi
 

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -132,6 +132,15 @@ else
     $BWRAP --unshare-user --disable-userns --dev-bind / / -- sh -c "echo 2 > /proc/sys/user/max_user_namespaces || true; ! $BWRAP --unshare-user --dev-bind / / -- true"
     $BWRAP --unshare-user --disable-userns --dev-bind / / -- sh -c "echo 100 > /proc/sys/user/max_user_namespaces || true; ! $BWRAP --unshare-user --dev-bind / / -- true"
     $BWRAP --unshare-user --disable-userns --dev-bind / / -- sh -c "! $BWRAP --unshare-user --dev-bind / / --assert-userns-disabled -- true"
+
+    $BWRAP_RECURSE --dev-bind / / -- true
+    ! $BWRAP_RECURSE --assert-userns-disabled --dev-bind / / -- true
+    $BWRAP_RECURSE --unshare-user --disable-userns --dev-bind / / -- true
+    ! $BWRAP_RECURSE --unshare-user --disable-userns --dev-bind / / -- /proc/self/exe --dev-bind / / -- true
+    $BWRAP_RECURSE --unshare-user --disable-userns --dev-bind / / -- sh -c "echo 2 > /proc/sys/user/max_user_namespaces || true; ! $BWRAP --unshare-user --dev-bind / / -- true"
+    $BWRAP_RECURSE --unshare-user --disable-userns --dev-bind / / -- sh -c "echo 100 > /proc/sys/user/max_user_namespaces || true; ! $BWRAP --unshare-user --dev-bind / / -- true"
+    $BWRAP_RECURSE --unshare-user --disable-userns --dev-bind / / -- sh -c "! $BWRAP --unshare-user --dev-bind / / --assert-userns-disabled -- true"
+
     echo "ok - can disable nested userns"
 fi
 


### PR DESCRIPTION
* tests: Explicitly unshare userns when testing --disable-userns
    
    If we're running the tests as uid 0 with capabilities, then bwrap will
    not create a new user namespace by default, which means the limit won't
    be exceeded and the test will fail. Make sure we always try to create
    the new user namespace.

* tests: Try harder to evade --disable-userns
    
    The worst-case scenario in terms of enforcing --disable-userns is that
    we're retaining all capabilities, so test that too, to make sure that
    the option is genuinely restricting even a privileged user.

---

The first commit is a 0.8.0 release blocker for me (although I could apply it as a downstream Debian patch if necessary), the second is just a nice-to-have for more thorough test coverage.

cc @alexlarsson @cgwalters 