### PR TITLE
Allocation improvements

### DIFF
--- a/bind-mount.c
+++ b/bind-mount.c
@@ -247,7 +247,7 @@ parse_mountinfo (int  proc_fd,
     die_with_error ("Can't open /proc/self/mountinfo");
 
   n_lines = count_lines (mountinfo);
-  lines = xcalloc (n_lines * sizeof (MountInfoLine));
+  lines = xcalloc (n_lines, sizeof (MountInfoLine));
 
   max_id = 0;
   line = mountinfo;
@@ -310,11 +310,11 @@ parse_mountinfo (int  proc_fd,
 
   if (root == -1)
     {
-      mount_tab = xcalloc (sizeof (MountInfo) * (1));
+      mount_tab = xcalloc (1, sizeof (MountInfo));
       return steal_pointer (&mount_tab);
     }
 
-  by_id = xcalloc ((max_id + 1) * sizeof (MountInfoLine*));
+  by_id = xcalloc (max_id + 1, sizeof (MountInfoLine*));
   for (i = 0; i < n_lines; i++)
     by_id[lines[i].id] = &lines[i];
 
@@ -366,7 +366,7 @@ parse_mountinfo (int  proc_fd,
     }
 
   n_mounts = count_mounts (&lines[root]);
-  mount_tab = xcalloc (sizeof (MountInfo) * (n_mounts + 1));
+  mount_tab = xcalloc (n_mounts + 1, sizeof (MountInfo));
 
   end_tab = collect_mounts (&mount_tab[0], &lines[root]);
   assert (end_tab == &mount_tab[n_mounts]);

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -213,7 +213,7 @@ static Type *last_ ## name = NULL; \
 static inline Type * \
 _ ## name ## _append_new (void) \
 { \
-  Type *self = xcalloc (sizeof (Type)); \
+  Type *self = xcalloc (1, sizeof (Type)); \
 \
   if (last_ ## name != NULL) \
     last_ ## name ->next = self; \
@@ -1720,7 +1720,7 @@ parse_args_recurse (int          *argcp,
                 p++;
             }
 
-          data_argv = xcalloc (sizeof (char *) * (data_argc + 1));
+          data_argv = xcalloc (data_argc + 1, sizeof (char *));
 
           i = 0;
           p = opt_args_data;

--- a/utils.c
+++ b/utils.c
@@ -19,6 +19,7 @@
 #include "config.h"
 
 #include "utils.h"
+#include <stdint.h>
 #include <sys/syscall.h>
 #include <sys/socket.h>
 #ifdef HAVE_SELINUX
@@ -594,6 +595,12 @@ load_file_data (int     fd,
     {
       if (data_len == data_read + 1)
         {
+          if (data_len > SIZE_MAX / 2)
+            {
+              errno = EFBIG;
+              return NULL;
+            }
+
           data_len *= 2;
           data = xrealloc (data, data_len);
         }
@@ -820,6 +827,8 @@ readlink_malloc (const char *pathname)
 
   do
     {
+      if (size > SIZE_MAX / 2)
+        die ("Symbolic link target pathname too long");
       size *= 2;
       value = xrealloc (value, size);
       n = readlink (pathname, value, size - 1);

--- a/utils.c
+++ b/utils.c
@@ -156,9 +156,13 @@ xcalloc (size_t nmemb, size_t size)
 void *
 xrealloc (void *ptr, size_t size)
 {
-  void *res = realloc (ptr, size);
+  void *res;
 
-  if (size != 0 && res == NULL)
+  assert (size != 0);
+
+  res = realloc (ptr, size);
+
+  if (res == NULL)
     die_oom ();
   return res;
 }

--- a/utils.c
+++ b/utils.c
@@ -143,9 +143,9 @@ xmalloc (size_t size)
 }
 
 void *
-xcalloc (size_t size)
+xcalloc (size_t nmemb, size_t size)
 {
-  void *res = calloc (1, size);
+  void *res = calloc (nmemb, size);
 
   if (res == NULL)
     die_oom ();

--- a/utils.h
+++ b/utils.h
@@ -66,7 +66,7 @@ void  die_unless_label_valid (const char *label);
 void  fork_intermediate_child (void);
 
 void *xmalloc (size_t size);
-void *xcalloc (size_t size);
+void *xcalloc (size_t nmemb, size_t size);
 void *xrealloc (void  *ptr,
                 size_t size);
 char *xstrdup (const char *str);


### PR DESCRIPTION
* Rework xcalloc

    Pass the first parameter to calloc(3) to perform the overflow check.

* Avoid undefined behavior in realloc

    Passing a NULL pointer and a size of 0 is currently implementation defined behavior[1] and will become (with C23) undefined behavior[2].

    [1]: https://manpages.debian.org/unstable/manpages-dev/realloc.3.en.html
    [2]: https://en.cppreference.com/w/c/memory/realloc