### PR TITLE
Ensure files do not exist already

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -482,15 +482,22 @@ ensure_file (const char *path,
      We're trying to set up a mount point for a non-directory, so any
      non-directory, non-symlink is acceptable - it doesn't necessarily
      have to be a regular file. */
-  if (stat (path, &buf) ==  0 &&
-      !S_ISDIR (buf.st_mode) &&
-      !S_ISLNK (buf.st_mode))
-    return 0;
+  if (stat (path, &buf) == 0)
+  {
+    if (S_ISDIR (buf.st_mode) ||
+        S_ISLNK (buf.st_mode))
+    {
+      errno = EEXIST;
+      return -1;
+    }
 
-  if (create_file (path, mode, NULL) != 0 &&  errno != EEXIST)
+    return 0;
+  }
+
+  if (errno != ENOENT)
     return -1;
 
-  return 0;
+  return create_file (path, mode, NULL);
 }
 
 
@@ -662,10 +669,10 @@ ensure_dir (const char *path,
       return 0;
     }
 
-  if (mkdir (path, mode) == -1 && errno != EEXIST)
+  if (errno != ENOENT)
     return -1;
 
-  return 0;
+  return mkdir (path, mode);
 }
 
 

--- a/utils.c
+++ b/utils.c
@@ -454,7 +454,7 @@ create_file (const char *path,
   int res;
   int errsv;
 
-  fd = creat (path, mode);
+  fd = open (path, O_WRONLY | O_CREAT | O_EXCL | O_TRUNC | O_CLOEXEC, mode);
   if (fd == -1)
     return -1;
 


### PR DESCRIPTION
Ensure the files created within create_file() do not exist before to avoid ownership or permissions being wrongly inherited.