### PR TITLE
Create a new terminal session by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ bwrap \
     --proc /proc \
     --dev /dev \
     --unshare-pid \
-    --new-session \
     bash
 ```
 
@@ -166,8 +165,8 @@ UTS namespace ([CLONE_NEWUTS](http://linux.die.net/man/2/clone)): The sandbox wi
 
 Seccomp filters: You can pass in seccomp filters that limit which syscalls can be done in the sandbox. For more information, see [Seccomp](https://en.wikipedia.org/wiki/Seccomp).
 
-If you are not filtering out `TIOCSTI` commands using seccomp filters,
-argument `--new-session` is needed to protect against out-of-sandbox
+If you are using the argument `--no-new-session`, filtering out `TIOCSTI`
+commands using seccomp filters is needed to protect against out-of-sandbox
 command execution
 (see [CVE-2017-5226](https://github.com/containers/bubblewrap/issues/142)).
 

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -84,7 +84,7 @@ bool opt_unshare_uts = FALSE;
 bool opt_unshare_cgroup = FALSE;
 bool opt_unshare_cgroup_try = FALSE;
 bool opt_needs_devpts = FALSE;
-bool opt_new_session = FALSE;
+bool opt_no_new_session = FALSE;
 bool opt_die_with_parent = FALSE;
 uid_t opt_sandbox_uid = -1;
 gid_t opt_sandbox_gid = -1;
@@ -357,7 +357,7 @@ usage (int ecode, FILE *out)
            "    --userns-block-fd FD         Block on FD until the user namespace is ready\n"
            "    --info-fd FD                 Write information about the running container to FD\n"
            "    --json-status-fd FD          Write container status to FD as multiple JSON documents\n"
-           "    --new-session                Create a new terminal session\n"
+           "    --no-new-session             Don't create a new terminal session\n"
            "    --die-with-parent            Kills with SIGKILL child process (COMMAND) when bwrap or bwrap's parent dies.\n"
            "    --as-pid-1                   Do not install a reaper process with PID=1\n"
            "    --cap-add CAP                Add cap CAP when running as privileged user\n"
@@ -2349,9 +2349,13 @@ parse_args_recurse (int          *argcp,
           argv += 1;
           argc -= 1;
         }
+      else if (strcmp (arg, "--no-new-session") == 0)
+        {
+          opt_no_new_session = TRUE;
+        }
       else if (strcmp (arg, "--new-session") == 0)
         {
-          opt_new_session = TRUE;
+          warn ("--new-session is deprecated, a new terminal session is now created by default");
         }
       else if (strcmp (arg, "--die-with-parent") == 0)
         {
@@ -3272,7 +3276,7 @@ main (int    argc,
   xsetenv ("PWD", new_cwd, 1);
   free (old_cwd);
 
-  if (opt_new_session &&
+  if (!opt_no_new_session &&
       setsid () == (pid_t) -1)
     die_with_error ("setsid");
 

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -456,14 +456,15 @@
       </para></listitem>
     </varlistentry>
     <varlistentry>
-      <term><option>--new-session</option></term>
+      <term><option>--no-new-session</option></term>
       <listitem><para>
-	Create a new terminal session for the sandbox (calls setsid()). This
-        disconnects the sandbox from the controlling terminal which means
-        the sandbox can't for instance inject input into the terminal.
+	Don't create a new terminal session for the sandbox (won't call setsid()). 
+        Creating a new session disconnects the sandbox from the controlling 
+        terminal which means the sandbox can't for instance inject input 
+        into the terminal.
         </para><para>
-        Note: In a general sandbox, if you don't use --new-session, it is
-        recommended to use seccomp to disallow the TIOCSTI ioctl, otherwise
+        Note: In a general sandbox, if you decide to use --no-new-session, it
+        is recommended to use seccomp to disallow the TIOCSTI ioctl, otherwise
         the application can feed keyboard input to the terminal
         which can e.g. lead to out-of-sandbox command execution
         (see CVE-2017-5226).

--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -14,7 +14,7 @@ _bwrap() {
 		--clearenv
 		--disable-userns
 		--help
-		--new-session
+		--no-new-session
 		--unshare-all
 		--unshare-cgroup
 		--unshare-cgroup-try

--- a/completions/zsh/_bwrap
+++ b/completions/zsh/_bwrap
@@ -52,7 +52,7 @@ _bwrap_args=(
     '--json-status-fd[Write container status to FD as multiple JSON documents]: :_guard "[0-9]#" "file descriptor to write to"'
     '--lock-file[Take a lock on DEST while sandbox is running]:lock file:_files'
     '--mqueue[Mount new mqueue on DEST]:mount point for mqueue:_files -/'
-    '--new-session[Create a new terminal session]'
+    '--no-new-session[Don\'t create a new terminal session]'
     '--perms[Set permissions for next action argument]: :_guard "[0-7]#" "permissions in octal": :->after_perms'
     '--pidns[Use this user namespace (as parent namespace if using --unshare-pid)]: :'
     '--proc[Mount new procfs on DEST]:mount point for procfs:_files -/'


### PR DESCRIPTION
This pull request will make it so that Bubblewrap will create a new terminal session by default and will allow users to opt out of this with a new parameter "--no-new-session" (parameter "--new-session" will be deprecated), instead of having to opt in with "--new-session". This will, in my opinion, make Bubblewrap more secure for new users who aren't completely familiar with it. (Fixes #555)