### PR TITLE
Fixes for autoconf/automake.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -99,4 +99,5 @@ endif
 
 AM_DISTCHECK_CONFIGURE_FLAGS =		\
 	--with-bash-completion-dir="\$(datadir)"/bash-completion/ \
+	--disable-dependency-tracking \
 	$(NULL)

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 
 AC_USE_SYSTEM_EXTENSIONS
 
-AM_INIT_AUTOMAKE([1.11 -Wno-portability foreign no-define tar-ustar no-dist-gzip dist-xz])
+AM_INIT_AUTOMAKE([1.11 -Wno-portability foreign no-define tar-ustar no-dist-gzip dist-xz subdir-objects])
 AM_MAINTAINER_MODE([enable])
 AM_SILENT_RULES([yes])
 


### PR DESCRIPTION
Solves three issues I ran into when executing autogen.sh on my system.

First, pkg-config is in a non-standard location, so I had to copy pkg.m4 into m4. Note this file is copyrighted under the GPL-2, which matches the bubblewrap copyright.

Second, automake 1.16.3 emits warnings about future deprecation of its old behavior - putting object files at the top-level. Silencing these warnings requires changing the AM_INIT_AUTOMAKE call from configure.ac.

Third, the manual rule for test-wrap in Makefile-bwrap.in threw a warning because automake [renames the target of things in TESTS](gnu.org/software/automake/manual/html_node/Extending.html).

Note: the full error traceback from autoreconf -i is here:
```
configure.ac:7: installing 'build-aux/compile'
configure.ac:9: installing 'build-aux/install-sh'
configure.ac:9: installing 'build-aux/missing'
configure.ac:141: installing 'build-aux/tap-driver.sh'
Makefile-bwrap.am:1: warning: source file '$(bwrap_srcpath)/bubblewrap.c' is in a subdirectory,
Makefile-bwrap.am:1: but option 'subdir-objects' is disabled
Makefile.am:32:   'Makefile-bwrap.am' included from here
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
Makefile-bwrap.am:1: warning: source file '$(bwrap_srcpath)/bind-mount.c' is in a subdirectory,
Makefile-bwrap.am:1: but option 'subdir-objects' is disabled
Makefile.am:32:   'Makefile-bwrap.am' included from here
Makefile-bwrap.am:1: warning: source file '$(bwrap_srcpath)/network.c' is in a subdirectory,
Makefile-bwrap.am:1: but option 'subdir-objects' is disabled
Makefile.am:32:   'Makefile-bwrap.am' included from here
Makefile-bwrap.am:1: warning: source file '$(bwrap_srcpath)/utils.c' is in a subdirectory,
Makefile-bwrap.am:1: but option 'subdir-objects' is disabled
Makefile.am:32:   'Makefile-bwrap.am' included from here
Makefile.am:54: warning: deprecated feature: target 'test-bwrap' overrides 'test-bwrap$(EXEEXT)'
Makefile.am:54: change your target to read 'test-bwrap$(EXEEXT)'
.../share/automake-1.16/am/program.am: target 'test-bwrap$(EXEEXT)' was defined here
Makefile.am:49:   while processing program 'test-bwrap'
Makefile.am:63: warning: source file 'tests/test-utils.c' is in a subdirectory,
Makefile.am:63: but option 'subdir-objects' is disabled
automake: warning: source file 'tests/try-syscall.c' is in a subdirectory,
automake: but option 'subdir-objects' is disabled
Makefile.am:49:   while processing program 'tests/try-syscall'
Makefile.am: installing 'build-aux/depcomp'
parallel-tests: installing 'build-aux/test-driver'
autoreconf: automake failed with exit status: 1
```