### PR TITLE
Add get_current_dir_name from musl to fix building on Bionic libc

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -53,6 +53,14 @@
        __result; }))
 #endif
 
+/* Bionic doesnt include this C function, so
+ * we pull it from the musl source tree for use here.
+ * Should be possible to add more checks for other libcs
+ * when needed. */
+#ifdef __BIONIC__
+#include "get_current_dir_name.c"
+#endif
+
 /* We limit the size of a tmpfs to half the architecture's address space,
  * to avoid hitting arbitrary limits in the kernel.
  * For example, on at least one x86_64 machine, the actual limit seems to be

--- a/get_current_dir_name.c
+++ b/get_current_dir_name.c
@@ -1,4 +1,4 @@
-Copyright © 2005-2020 Rich Felker, et al., 2023 Dallas Strouse
+/* Copyright © 2005-2020 Rich Felker, et al., 2023 Dallas Strouse
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -18,7 +18,7 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+*/
 
 #include <stdlib.h>
 #include <string.h>

--- a/get_current_dir_name.c
+++ b/get_current_dir_name.c
@@ -1,0 +1,37 @@
+Copyright © 2005-2020 Rich Felker, et al., 2023 Dallas Strouse
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static char *get_current_dir_name(void) {
+	struct stat a, b;
+	char *res = getenv("PWD");
+	if (res && *res && !stat(res, &a) && !stat(".", &b)
+	    && (a.st_dev == b.st_dev) && (a.st_ino == b.st_ino))
+		return strdup(res);
+	return getcwd(0, 0);
+}
+


### PR DESCRIPTION
get_current_dir_name is a GNU function, and is not supported on all C libraries. Bionic is the main one here, as musl provides the get_current_dir_name we're using here.

We mostly copy-paste the musl implementation in order to fix building on the Bionic libc. Bubblewrap will now build and run successfully on Android.

Note that Android currently prohibits user namespaces and suid programs, so this needs root access to function.

Closes  https://github.com/containers/bubblewrap/issues/579