### PR TITLE
Add --foreground option

### DIFF
--- a/bwrap.xml
+++ b/bwrap.xml
@@ -470,6 +470,14 @@
       </para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--foreground</option></term>
+      <listitem><para>
+	Create a new process group for the sandbox (calls setpgid()) and make it the
+        foreground process group of the controlling terminal if there is a
+        controlling terminal.
+      </para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--die-with-parent</option></term>
       <listitem><para>
     Ensures child process (COMMAND) dies when bwrap's parent dies. Kills (SIGKILL)

--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -13,6 +13,7 @@ _bwrap() {
 		--assert-userns-disabled
 		--clearenv
 		--disable-userns
+		--foreground
 		--help
 		--new-session
 		--unshare-all

--- a/completions/zsh/_bwrap
+++ b/completions/zsh/_bwrap
@@ -45,6 +45,7 @@ _bwrap_args=(
     '--disable-userns[Disable further use of user namespaces inside sandbox]'
     '--exec-label[Exec label for the sandbox]:SELinux label:_selinux_contexts'
     '--file-label[File label for temporary sandbox content]:SELinux label:_selinux_contexts'
+    '--foreground[Create a new process group and make it the foreground process group]'
     '--gid[Custom gid in the sandbox (requires --unshare-user or --userns)]: :_guard "[0-9]#" "numeric group ID"'
     '--help[Print help and exit]'
     '--hostname[Custom hostname in the sandbox (requires --unshare-uts)]:hostname:'


### PR DESCRIPTION
This option creates a new process group for the child process and if there's a controlling terminal, makes the new process group the foreground process group of the controlling terminal. This makes sure that SIGINT signals generated by CTRL+C are only sent to the child process and not to bubblewrap itself.

While this can also be achieved with external utilities (e.g. https://github.com/util-linux/util-linux/pull/2445), it still makes sense to support this natively in bubblewrap to avoid the need to install any other utilities in the sandbox to be able to make the child process the foreground process group of the controlling terminal.

Fixes #369