### PR TITLE
Falling back to chroot() if pivot_root() fails

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -3146,7 +3146,7 @@ main (int    argc,
 
   if (umount2 ("oldroot", MNT_DETACH))
     die_with_error ("unmount old root");
-
+#if 0
   /* This is our second pivot. It's like we're a Silicon Valley startup flush
    * with cash but short on ideas!
    *
@@ -3177,7 +3177,7 @@ main (int    argc,
     if (chdir ("/") != 0)
       die_with_error ("chdir /");
   }
-
+#endif
   if (opt_userns2_fd > 0 && setns (opt_userns2_fd, CLONE_NEWUSER) != 0)
     die_with_error ("Setting userns2 failed");
 
@@ -3229,7 +3229,15 @@ main (int    argc,
       if (res == 0)
         die ("creation of new user namespaces was not disabled as requested");
     }
-
+#if 1
+  /* Now make /newroot the real root */
+  if (chdir ("/newroot") != 0)
+    die_with_error ("chdir newroot");
+  if (chroot ("/newroot") != 0)
+    die_with_error ("chroot /newroot");
+  if (chdir ("/") != 0)
+    die_with_error ("chdir /");
+#endif
   /* All privileged ops are done now, so drop caps we don't need */
   drop_privs (!is_privileged, TRUE);
 

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -3080,10 +3080,16 @@ main (int    argc,
 
   if (mkdir ("oldroot", 0755))
     die_with_error ("Creating oldroot failed");
-
+#if 0
   if (pivot_root (base_path, "oldroot"))
     die_with_error ("pivot_root");
+#else
+  if (mount ("/", "oldroot", NULL, MS_SILENT | MS_MGC_VAL | MS_BIND | MS_REC, NULL) < 0)
+    die_with_error ("setting up newroot bind");
 
+  if (chroot (base_path))
+    die_with_error ("chroot");
+#endif
   if (chdir ("/") != 0)
     die_with_error ("chdir / (base path)");
 
@@ -3209,16 +3215,17 @@ main (int    argc,
           if (write_to_fd (sysctl_fd, "1", 1) < 0)
             die_with_error ("sysctl user.max_user_namespaces = 1");
         }
-
+#if 0
       if (unshare (CLONE_NEWUSER))
         die_with_error ("unshare user ns");
-
+#endif
       /* We're in a new user namespace, we got back the bounding set, clear it again */
       drop_cap_bounding_set (FALSE);
-
+#if 0
       write_uid_gid_map (opt_sandbox_uid, ns_uid,
                          opt_sandbox_gid, ns_gid,
                          -1, FALSE, FALSE);
+#endif
     }
 
   if (opt_disable_userns || opt_assert_userns_disabled)


### PR DESCRIPTION
In #594 I've found that bubblewrap fails due to `pivot_root()`, when binding folder on an NFS filesystem. It would be a pity to fail the entire bubblewrap due to this problem. So I propose a fallback mode: if `pivot_root()` fails, we try to continue setup with `chroot()`. Yes: `chroot()` yields some limitations, such as disabled unsharing mode and disabled uid/gid mapping. But it is still better than nothing, isn't it?