### PR TITLE
Add --exec PATH to set the file to execute separate from argv[0]

### DIFF
--- a/bwrap.xml
+++ b/bwrap.xml
@@ -85,6 +85,10 @@
       <listitem><para>Print version</para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--exec-filename <arg choice="plain">PATH</arg></option></term>
+      <listitem><para>Execute <arg choice="plain">PATH</arg> instead of COMMAND.</para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--args <arg choice="plain">FD</arg></option></term>
       <listitem><para>
         Parse nul-separated arguments from the given file descriptor.

--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -43,6 +43,7 @@ _bwrap() {
 		--dev-bind
 		--die-with-parent
 		--dir
+		--exec-filename
 		--exec-label
 		--file
 		--file-label

--- a/completions/zsh/_bwrap
+++ b/completions/zsh/_bwrap
@@ -43,6 +43,7 @@ _bwrap_args=(
     '--dev[Mount new dev on DEST]:mount point for /dev:_files -/'
     "--die-with-parent[Kills with SIGKILL child process (COMMAND) when bwrap or bwrap's parent dies.]"
     '--disable-userns[Disable further use of user namespaces inside sandbox]'
+    '--exec-filename[Execute PATH instead of COMMAND]'
     '--exec-label[Exec label for the sandbox]:SELinux label:_selinux_contexts'
     '--file-label[File label for temporary sandbox content]:SELinux label:_selinux_contexts'
     '--gid[Custom gid in the sandbox (requires --unshare-user or --userns)]: :_guard "[0-9]#" "numeric group ID"'

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -532,4 +532,14 @@ echo "PWD=$(pwd -P)" > reference
 assert_files_equal stdout reference
 echo "ok - environment manipulation"
 
+
+$RUN sh -c 'echo $0' > stdout
+assert_file_has_content stdout sh
+$RUN --exec-filename sh sh -c 'echo $0' > stdout
+assert_file_has_content stdout sh
+$RUN --exec-filename sh right -c 'echo $0' > stdout
+assert_file_has_content stdout right
+echo "ok - exec file and argv0 manipulation"
+
+
 echo "ok - End of test"


### PR DESCRIPTION
Fixes containers/bubblewrap#91

I realise that an initial Github issue was created for this feature in 2016 and it doesn't appear to have come up again since. However, NixOS is weird and creates a usecase for separating the executable path in the container from the command name. The nix-bubblewrap project also ran into the same issue, and has a note about it in their README: https://github.com/fgaz/nix-bubblewrap#troubeshooting

## Explanation

NixOS doesn't install executable binaries into /usr/bin, and instead installs each package into it's own immutable folder under `/nix/store/${hash}-${package}-${version}/bin`. NixOS also provides a command to list the packages a given package depends on. This makes it trivial to use bwrap to only --ro-bind the packages required for a given executable.

This all works wonderfully, except for two complications. To create a `$PATH` for a user's shell to use, NixOS creates folders of symlinks (often to other symlinks) for `$PATH` to reference. These folders of symlinks to executables could be --ro-bind into the container, but they're only needed to locate the initial executable for the command. We can just `$(realpath $(which command))` and pass that to bwrap, except that fails for executables that change their behavior based on the command name used (say, bash behaving as sh, xz behaving as unxz, or coreutils behaving as date, df, cat, ...).

We could also have NixOS build a `$PATH` for just the packages needed, and use that when running bwrap, but we've already located the binary, and have the command name, we just need to have bwrap use the executable path and the argv[0] provided.

## Concrete example

The $PATH points to a folder of symlinks to symlinks to symlinks. The two levels of symlink folders don't need to be in the container, they're just needed to locate the executable for the command. In this case, date command is actually a symlink to the coreutils executable.

```
% which date
/home/quag/.nix-profile/bin/date
% readlink $(which date)
/nix/store/8nzn8ghzknqgjsg1iv124qy0fjli3dwn-home-manager-path/bin/date
% readlink $(readlink $(which date))
/nix/store/apn3p2b40xvirn7w740wv2gy330ppib5-coreutils-9.3/bin/date
% readlink $(readlink $(readlink $(which date)))
/nix/store/apn3p2b40xvirn7w740wv2gy330ppib5-coreutils-9.3/bin/coreutils
```

Coreutils only needs the following file system to be able to execute.

```
% nix-store --query --requisites $(realpath $(which coreutils))
/nix/store/3wwfqhdym0sbis4bad1may3ll8rki8y1-gcc-12.3.0-libgcc
/nix/store/jbwb8d8l28lg9z0xzl784wyb9vlbwss6-xgcc-12.3.0-libgcc
/nix/store/s2gi8pfjszy6rq3ydx0z1vwbbskw994i-libunistring-1.1
/nix/store/k8ivghpggjrq1n49xp8sj116i4sh8lia-libidn2-2.3.4
/nix/store/aw2fw9ag10wr9pf0qk4nk5sxi0q0bn56-glibc-2.37-8
/nix/store/srrs7gn04rwa4f6zhsjkdacxydwrmzhj-attr-2.5.1
/nix/store/aj6gbshd8hvifpa1d8vy0iv688sm81wp-acl-2.3.1
/nix/store/xpxln7rqi3pq4m0xpnawhxb2gs0mn1s0-gcc-12.3.0-lib
/nix/store/yqa5m326a0ynn4whm4fikyjfljfc6i3q-gmp-with-cxx-6.3.0
/nix/store/apn3p2b40xvirn7w740wv2gy330ppib5-coreutils-9.3
```
These ten directories can be --ro-bind into the container and the --ro-binds can be generated with sed.

```
% function nix-bwrap-args() {
    nix-store --query --requisites $(realpath $(which $1)) \
    | sed 's/.*/--ro-bind & &/' \
    | tr '\n' ' '
}
```

However, despite having all the files needed in the container, bwrap resolves date using $PATH to /home/quag/.nix-profile/bin/date which isn't in the container.

```
% bwrap $(nix-bwrap-args date) date
bwrap: execvp date: No such file or directory
```

If we resolve the date command to the executable in the container (the coreutils binary), then that fails, as it doesn't know which command it is meant to be impersonating.

```
% bwrap $(nix-bwrap-args date) $(realpath $(which date))
Try '/nix/store/apn3p2b40xvirn7w740wv2gy330ppib5-coreutils-9.3/bin/coreutils --help' for more information.
```

If we add an --exec command that takes the executable within the container to run, and then passes through the command without resolving it, everything works. A minimal container, with executable resolution happening before entering the container while retaining the command name.

```
% bwrap $(nix-bwrap-args date) --exec $(realpath $(which date)) date
Wed Sep 27 05:50:49 UTC 2023
```

## FAQ

Q1. Doesn't the running process need a valid $PATH to locate other commands it depends on?

Surprisingly no. To support installing multiple versions of the same package, all references to other packages (including executables) are compiled into the binaries as paths into /nix/store/*/*. This means that after the program starts, $PATH is not needed again.

[edited to avoid some weird Markdown formatting —smcv]