### PR TITLE
utils: Move get_newroot_path to utils

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -944,14 +944,6 @@ drop_privs (bool keep_requested_caps,
     die_with_error ("can't set dumpable");
 }
 
-static char *
-get_newroot_path (const char *path)
-{
-  while (*path == '/')
-    path++;
-  return strconcat ("/newroot/", path);
-}
-
 static void
 write_uid_gid_map (uid_t sandbox_uid,
                    uid_t parent_uid,

--- a/utils.c
+++ b/utils.c
@@ -823,6 +823,14 @@ get_oldroot_path (const char *path)
   return strconcat ("/oldroot/", path);
 }
 
+char *
+get_newroot_path (const char *path)
+{
+  while (*path == '/')
+    path++;
+  return strconcat ("/newroot/", path);
+}
+
 int
 raw_clone (unsigned long flags,
            void         *child_stack)

--- a/utils.h
+++ b/utils.h
@@ -121,6 +121,7 @@ void create_pid_socketpair (int sockets[2]);
 void send_pid_on_socket (int socket);
 int  read_pid_from_socket (int socket);
 char *get_oldroot_path (const char *path);
+char *get_newroot_path (const char *path);
 char *readlink_malloc (const char *pathname);
 
 /* syscall wrappers */


### PR DESCRIPTION
We already have `get_oldroot_path` in utils, so let's be consistent about this.