### PR TITLE
Make test "can pivot to new rootfs recursively" work on NixOS

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -94,9 +94,10 @@ else
     BWRAP_RO_HOST_ARGS="--ro-bind /usr /usr
               --ro-bind /etc /etc
               --ro-bind /bin /bin
-              --ro-bind /lib /lib
+              --ro-bind-try /lib /lib
               --ro-bind-try /lib64 /lib64
-              --ro-bind /sbin /sbin
+              --ro-bind-try /sbin /sbin
+              --ro-bind-try /nix/store /nix/store
               --dir /var/tmp
               --proc /proc
               --dev /dev"


### PR DESCRIPTION
The "can pivot to new rootfs recursively" test is the only test that fails due to the quirks of NixOS. Specifically, NixOS does not have /lib or /sbin directories. To fix, I've made /lib and /sbin --ro-bind-try instead of --ro-bind.

Adding --ro-bind-try /nix/store /nix-store as findmnt is located there. As this is the only use of findmnt in the tests, we could also use an alternative way to check if /usr has been mounted in the container.

As NixOS is out of step with mainstream Linux distros, I understand if bubblewrap doesn't want to support it for it's tests.