### PR TITLE
Add testing instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ meson:
 ```
 meson _builddir
 meson compile -C _builddir
+meson test -C _builddir
 meson install -C _builddir
 ```
 


### PR DESCRIPTION
When first making changes to bubblewrap, I couldn't find instructions for how to run the tests. This pull request adds instructions to the installation section of the README.md to run the tests before installing. An alternative would be to add a DEVELOPING section to the README.md and list how to test there.