### PR TITLE
Silence Automake warning for items in TESTS being renamed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,7 +51,7 @@ test_extra_programs = \
 	tests/try-syscall \
 	$(NULL)
 
-test-bwrap: bwrap
+test-bwrap$(EXEEXT): bwrap
 	rm -rf test-bwrap
 	cp bwrap test-bwrap
 	chmod 0755 test-bwrap


### PR DESCRIPTION
From: @frobnitzem

The manual rule for test-bwrap in Makefile-bwrap.in threw a warning because automake [renames the target of things in TESTS](https://www.gnu.org/software/automake/manual/html_node/Extending.html).

[smcv: Split out from a larger commit, re-worded commit message]