### PR TITLE
tests: use stat -c instead of --format for compatibility

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -109,7 +109,7 @@ assert_file_has_content json-status.json '"child-pid": [0-9]'
 assert_file_has_content_literal json-status.json '"exit-code": 42'
 ok "info and json-status fd"
 
-DATA=$($RUN --proc /proc --unshare-all --info-fd 42 --json-status-fd 43 -- bash -c 'stat -L --format "%n %i" /proc/self/ns/*' 42>info.json 43>json-status.json 2>err.txt)
+DATA=$($RUN --proc /proc --unshare-all --info-fd 42 --json-status-fd 43 -- bash -c 'stat -L -c "%n %i" /proc/self/ns/*' 42>info.json 43>json-status.json 2>err.txt)
 
 for NS in "ipc" "mnt" "net" "pid" "uts"; do
 


### PR DESCRIPTION
eg. busybox stat only has -c and not --format