### PR TITLE
Add new --level-prefix option

### DIFF
--- a/bind-mount.c
+++ b/bind-mount.c
@@ -560,6 +560,9 @@ die_with_bind_result (bind_mount_result res,
   bool want_errno = TRUE;
   char *message;
 
+  if (bwrap_level_prefix)
+    fprintf (stderr, "<%d>", LOG_ERR);
+
   fprintf (stderr, "bwrap: ");
 
   va_start (args, format);

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -311,6 +311,7 @@ usage (int ecode, FILE *out)
            "    --version                    Print version\n"
            "    --args FD                    Parse NUL-separated args from FD\n"
            "    --argv0 VALUE                Set argv[0] to the value VALUE before running the program\n"
+           "    --level-prefix               Prepend e.g. <3> to diagnostic messages\n"
            "    --unshare-all                Unshare every namespace we support by default\n"
            "    --share-net                  Retain the network namespace (can only combine with --unshare-all)\n"
            "    --unshare-user               Create new user namespace (may be automatically implied if not setuid)\n"
@@ -1777,6 +1778,10 @@ parse_args_recurse (int          *argcp,
           opt_argv0 = argv[1];
           argv++;
           argc--;
+        }
+      else if (strcmp (arg, "--level-prefix") == 0)
+        {
+          bwrap_level_prefix = TRUE;
         }
       else if (strcmp (arg, "--unshare-all") == 0)
         {

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2841,7 +2841,7 @@ main (int    argc,
   if (argc <= 0)
     usage (EXIT_FAILURE, stderr);
 
-  __debug__ (("Creating root mount point\n"));
+  debug ("Creating root mount point");
 
   if (opt_sandbox_uid == (uid_t)-1)
     opt_sandbox_uid = real_uid;
@@ -2877,7 +2877,7 @@ main (int    argc,
    * access ourselves. */
   base_path = "/tmp";
 
-  __debug__ (("creating new namespace\n"));
+  debug ("creating new namespace");
 
   if (opt_unshare_pid && !opt_as_pid_1)
     {
@@ -3354,7 +3354,7 @@ main (int    argc,
   if (label_exec (opt_exec_label) == -1)
     die_with_error ("label_exec %s", argv[0]);
 
-  __debug__ (("forking for child\n"));
+  debug ("forking for child");
 
   if (!opt_as_pid_1 && (opt_unshare_pid || lock_files != NULL || opt_sync_fd != -1))
     {
@@ -3392,7 +3392,7 @@ main (int    argc,
         }
     }
 
-  __debug__ (("launch executable %s\n", argv[0]));
+  debug ("launch executable %s", argv[0]);
 
   if (proc_fd != -1)
     close (proc_fd);

--- a/bwrap.xml
+++ b/bwrap.xml
@@ -96,6 +96,26 @@
       <term><option>--argv0 <arg choice="plain">VALUE</arg></option></term>
       <listitem><para>Set argv[0] to the value <arg choice="plain">VALUE</arg> before running the program</para></listitem>
     </varlistentry>
+    <varlistentry>
+      <term><option>--level-prefix</option></term>
+      <listitem>
+        <para>
+          Prefix each line of diagnostic output with a numeric severity
+          level enclosed in angle brackets.
+          The severity levels used are based on the constants used by
+          <citerefentry><refentrytitle>syslog</refentrytitle><manvolnum>3</manvolnum></citerefentry>:
+          for example, <literal>&lt;4&gt;</literal> indicates a warning,
+          because <literal>LOG_WARNING</literal> has numeric value 4.
+          Numbers smaller than 4 indicate fatal errors, and numbers larger
+          than 4 indicate informational messages.
+          These prefixes can be parsed by tools compatible with
+          <literal>logger --prio-prefix</literal> (see
+          <citerefentry><refentrytitle>logger</refentrytitle><manvolnum>1</manvolnum></citerefentry>)
+          or <literal>systemd-cat --level-prefix=1</literal> (see
+          <citerefentry><refentrytitle>systemd-cat</refentrytitle><manvolnum>1</manvolnum></citerefentry>).
+        </para>
+      </listitem>
+    </varlistentry>
   </variablelist>
   <para>Options related to kernel namespaces:</para>
   <variablelist>

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -575,4 +575,8 @@ $RUN --chdir / --chdir / true > stdout 2>&1
 assert_file_has_content stdout '^bwrap: Only the last --chdir option will take effect$'
 ok "warning logged for redundant --chdir"
 
+$RUN --level-prefix --chdir / --chdir / true > stdout 2>&1
+assert_file_has_content stdout '^<4>bwrap: Only the last --chdir option will take effect$'
+ok "--level-prefix"
+
 done_testing

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -571,4 +571,8 @@ assert_file_has_content stdout foobar
 
 ok "bind-fd"
 
+$RUN --chdir / --chdir / true > stdout 2>&1
+assert_file_has_content stdout '^bwrap: Only the last --chdir option will take effect$'
+ok "warning logged for redundant --chdir"
+
 done_testing

--- a/utils.c
+++ b/utils.c
@@ -34,10 +34,11 @@
 #define security_check_context(x) security_check_context ((security_context_t) x)
 #endif
 
-__attribute__((format(printf, 1, 0))) static void
-warnv (const char *format,
-       va_list args,
-       const char *detail)
+__attribute__((format(printf, 2, 0))) static void
+bwrap_logv (int severity,
+            const char *format,
+            va_list args,
+            const char *detail)
 {
   fprintf (stderr, "bwrap: ");
   vfprintf (stderr, format, args);
@@ -49,12 +50,13 @@ warnv (const char *format,
 }
 
 void
-warn (const char *format, ...)
+bwrap_log (int severity,
+           const char *format, ...)
 {
   va_list args;
 
   va_start (args, format);
-  warnv (format, args, NULL);
+  bwrap_logv (severity, format, args, NULL);
   va_end (args);
 }
 
@@ -67,7 +69,7 @@ die_with_error (const char *format, ...)
   errsv = errno;
 
   va_start (args, format);
-  warnv (format, args, strerror (errsv));
+  bwrap_logv (LOG_ERR, format, args, strerror (errsv));
   va_end (args);
 
   exit (1);
@@ -82,7 +84,7 @@ die_with_mount_error (const char *format, ...)
   errsv = errno;
 
   va_start (args, format);
-  warnv (format, args, mount_strerror (errsv));
+  bwrap_logv (LOG_ERR, format, args, mount_strerror (errsv));
   va_end (args);
 
   exit (1);
@@ -94,7 +96,7 @@ die (const char *format, ...)
   va_list args;
 
   va_start (args, format);
-  warnv (format, args, NULL);
+  bwrap_logv (LOG_ERR, format, args, NULL);
   va_end (args);
 
   exit (1);

--- a/utils.c
+++ b/utils.c
@@ -34,12 +34,17 @@
 #define security_check_context(x) security_check_context ((security_context_t) x)
 #endif
 
+bool bwrap_level_prefix = FALSE;
+
 __attribute__((format(printf, 2, 0))) static void
 bwrap_logv (int severity,
             const char *format,
             va_list args,
             const char *detail)
 {
+  if (bwrap_level_prefix)
+    fprintf (stderr, "<%d>", severity);
+
   fprintf (stderr, "bwrap: ");
   vfprintf (stderr, format, args);
 

--- a/utils.h
+++ b/utils.h
@@ -53,6 +53,8 @@ typedef int bool;
 #define PR_SET_CHILD_SUBREAPER 36
 #endif
 
+extern bool bwrap_level_prefix;
+
 void  bwrap_log (int severity,
                  const char *format,
                  ...) __attribute__((format (printf, 2, 3)));

--- a/utils.h
+++ b/utils.h
@@ -27,14 +27,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <syslog.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 
 #if 0
-#define __debug__(x) printf x
+#define debug(...) bwrap_log (LOG_DEBUG, __VA_ARGS__)
 #else
-#define __debug__(x)
+#define debug(...)
 #endif
 
 #define UNUSED __attribute__((__unused__))
@@ -52,8 +53,11 @@ typedef int bool;
 #define PR_SET_CHILD_SUBREAPER 36
 #endif
 
-void  warn (const char *format,
-            ...) __attribute__((format (printf, 1, 2)));
+void  bwrap_log (int severity,
+                 const char *format,
+                 ...) __attribute__((format (printf, 2, 3)));
+#define warn(...) bwrap_log (LOG_WARNING, __VA_ARGS__)
+
 void  die_with_error (const char *format,
                       ...) __attribute__((__noreturn__)) __attribute__((format (printf, 1, 2)));
 void  die_with_mount_error (const char *format,


### PR DESCRIPTION
* test-run: Assert that repeating --chdir logs a warning
    
    This is the case since commit 0d369cd "main: Warn when
    non-repeatable options are repeated".

* utils: Put nearly all diagnostic output through a common log function
    
    This takes a syslog-style severity level, allowing us to act based on
    the severity.

    Take the opportunity to make the `__debug__` macro (which normally expands
    to nothing, but can be enabled by changing a `#if 0` to `#if 1`) less
    weird and easier to use, by taking it out of the reserved-for-the-compiler
    namespace, adding a newline automatically, and not requiring nested
    parentheses.
    
* Add new --level-prefix option
    
    This prepends a syslog-style priority level such as <3> to each line of
    diagnostic output, so that the diagnostic output can be parsed by
    tools like `systemd-cat --level-prefix=1`. A future version of Steam's
    pressure-vessel is likely to use this to make warnings and fatal errors
    from bubblewrap more visible.

cc @refi64 @RyuzakiKK 