### PR TITLE
meson: use boolean value for boolean options

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -45,7 +45,7 @@ option(
   'require_userns',
   type : 'boolean',
   description : 'require user namespaces by default when installed setuid',
-  value : 'false',
+  value : false,
 )
 option(
   'selinux',
@@ -57,7 +57,7 @@ option(
   'tests',
   type : 'boolean',
   description : 'build tests',
-  value : 'true',
+  value : true,
 )
 option(
   'zsh_completion',


### PR DESCRIPTION
string values for boolean options should be avoided and will be deprecated in a future version of meson.

Ref https://mesonbuild.com/Release-notes-for-1-1-0.html