### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+ignore-regex = \bassertIn\b
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ D-Bus communication.
 
 - Some applications deploy their own sandboxing mechanisms, and these can be
 restricted by the constraints imposed by bubblewrap's sandboxing.
-For example, some web browsers which configure their child proccesses via
+For example, some web browsers which configure their child processes via
 seccomp to not have access to the filesystem. If you limit the syscalls and
 don't allow the seccomp syscall, a browser cannot apply these restrictions.
 Similarly, if these rules were compiled into a file that is not available in

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -3264,7 +3264,7 @@ main (int    argc,
          used for one or more of these reasons:
 
          * The 1st level namespace has a different uid/gid than the
-           requested due to requirements of beeing root in the first
+           requested due to requirements of being root in the first
            level due for mounting devpts (opt_needs_devpts).
 
          * To disable user namespaces we set max_user_namespaces and then


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.