### PR TITLE
Update Github Actions configuration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Install build-dependencies
       run: sudo ./ci/builddeps.sh
     - name: Create logs dir
@@ -89,7 +89,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
     - name: Check out
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Install build-dependencies
       run: sudo ./ci/builddeps.sh --clang
     - run: meson build -Dselinux=enabled

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -69,7 +69,7 @@ jobs:
         test ! -e DESTDIR-as-subproject/usr/local/libexec/bwrap
         tests/use-as-subproject/assert-correct-rpath.py DESTDIR-as-subproject/usr/local/libexec/not-flatpak-bwrap
     - name: Upload test logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure() || cancelled()
       with:
         name: test logs


### PR DESCRIPTION
* workflows: Use upload-artifact@v4
    
    Reference: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

* workflows: Use latest version of actions/checkout
    
    It isn't entirely clear to me what the incompatibilities are, but
    hopefully in simple cases like ours it's functionally equivalent.