### PR TITLE
Ensure correct alignment when dealing with control messages

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -759,7 +759,7 @@ send_pid_on_socket (int sockfd)
   struct msghdr msg = {};
   struct iovec iov = { buf, sizeof (buf) };
   const ssize_t control_len_snd = CMSG_SPACE(sizeof(struct ucred));
-  char control_buf_snd[control_len_snd];
+  _Alignas(struct cmsghdr) char control_buf_snd[control_len_snd];
   struct cmsghdr *cmsg;
   struct ucred cred;
 
@@ -801,7 +801,7 @@ read_pid_from_socket (int sockfd)
   struct msghdr msg = {};
   struct iovec iov = { recv_buf, sizeof (recv_buf) };
   const ssize_t control_len_rcv = CMSG_SPACE(sizeof(struct ucred));
-  char control_buf_rcv[control_len_rcv];
+  _Alignas(struct cmsghdr) char control_buf_rcv[control_len_rcv];
   struct cmsghdr* cmsg;
 
   msg.msg_iov = &iov;


### PR DESCRIPTION
* utils: Don't assume cmsg data is aligned suitably for struct ucred
    
    As documented in cmsg(3), the alignment of control messages is not
    guaranteed, so for portability to architectures with strong alignment
    requirements we should memcpy to and from a suitably aligned instance
    of the desired data structure on the stack.
    
    Helps: https://github.com/containers/bubblewrap/issues/637

* utils: Ensure that the buffer for struct cmsghdr is suitably-aligned
    
    A char array on the stack is not guaranteed to have any particular
    alignment.
    
    Resolves: https://github.com/containers/bubblewrap/issues/637

cc @mcatanzaro @refi64