### PR TITLE
utils: Add a fallback version of xadd, xmul for ancient gcc

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -959,10 +959,17 @@ mount_strerror (int errsv)
 static size_t
 xadd (size_t a, size_t b)
 {
+#if defined(__GNUC__) && __GNUC__ >= 5
   size_t result;
   if (__builtin_add_overflow (a, b, &result))
     die_oom ();
   return result;
+#else
+  if (a > SIZE_MAX - b)
+    die_oom ();
+
+  return a + b;
+#endif
 }
 
 /*
@@ -972,10 +979,17 @@ xadd (size_t a, size_t b)
 static size_t
 xmul (size_t a, size_t b)
 {
+#if defined(__GNUC__) && __GNUC__ >= 5
   size_t result;
   if (__builtin_mul_overflow (a, b, &result))
     die_oom ();
   return result;
+#else
+  if (b != 0 && a > SIZE_MAX / b)
+    die_oom ();
+
+  return a * b;
+#endif
 }
 
 void


### PR DESCRIPTION
bubblewrap is used in some surprisingly old environments, including version 1 of the Steam Runtime, which has gcc 4.6 or 4.8 as its default compiler (depending on exactly how you define "default"). These very old versions don't support the builtin used here.

cc @refi64 @RyuzakiKK 