### PR TITLE
completions: Don't try to define more than one variable for pkg-config

### DIFF
--- a/completions/bash/meson.build
+++ b/completions/bash/meson.build
@@ -13,7 +13,6 @@ if bash_completion_dir == ''
         default_value: '',
         pkgconfig: 'completionsdir',
         pkgconfig_define: [
-          'prefix', get_option('prefix'),
           'datadir', get_option('prefix') / get_option('datadir'),
         ],
       )


### PR DESCRIPTION
Before Meson 1.3.0, this would not do what we meant (instead defining prefix to a wrong value composed from the remaining arguments).

The only reason we needed to redefine prefix in the first place is that bash-completion older than 2.10 did not allow users of its pkg-config file to override the datadir used to compute its completionsdir, but that was addressed in version 2.10 (2019). Users of older bash-completion should set bubblewrap's bash_completion_dir build option, if the automatically-discovered default is not appropriate.

Related to https://github.com/containers/bubblewrap/issues/609

/cc @refi64 @eli-schwartz