### PR TITLE
Added --sys argument for mounting sysfs

### DIFF
--- a/bwrap.xml
+++ b/bwrap.xml
@@ -406,6 +406,10 @@
       <listitem><para>Mount new devtmpfs on <arg choice="plain">DEST</arg></para></listitem>
     </varlistentry>
     <varlistentry>
+      <term><option>--sys <arg choice="plain">DEST</arg></option></term>
+      <listitem><para>Mount sysfs on <arg choice="plain">DEST</arg></para></listitem>
+    </varlistentry>
+    <varlistentry>
       <term><option>--tmpfs <arg choice="plain">DEST</arg></option></term>
       <listitem>
         <para>Mount new tmpfs on <arg choice="plain">DEST</arg>.

--- a/completions/bash/bwrap
+++ b/completions/bash/bwrap
@@ -63,6 +63,7 @@ _bwrap() {
 		--size
 		--symlink
 		--sync-fd
+		--sys
 		--tmp-overlay
 		--uid
 		--unsetenv

--- a/completions/zsh/_bwrap
+++ b/completions/zsh/_bwrap
@@ -65,6 +65,7 @@ _bwrap_args=(
     '--size[Set size in bytes for next action argument]: :->after_size'
     '--symlink[Create symlink at DEST with target SRC]:symlink target:_files:symlink to create:_files:'
     '--sync-fd[Keep this fd open while sandbox is running]: :_guard "[0-9]#" "file descriptor to keep open"'
+    '--sys[Mount new sysfs on DEST]:mount point for sysfs:_files -/'
     '--uid[Custom uid in the sandbox (requires --unshare-user or --userns)]: :_guard "[0-9]#" "numeric group ID"'
     '(--clearenv)--unsetenv[Unset an environment variable]:variable to unset:_parameters -g "*export*"'
     '--unshare-all[Unshare every namespace we support by default]'


### PR DESCRIPTION
Greetings,

I needed this feature (sysfs) for my own use-case and decided to implement it.
My goal is to do networking experiments inside of a container, as well as to simply isolate / abstract different parts of my local networking setup.
Most networking utilities on Linux require /sys to exist.

Mounting it after the fact is not easily possible in the upstream version:
I first needed to bind-mount the host's "/sys/" to "/sys_host" via bubblewrap and only then was I allowed to mount sysfs inside the container (and only with "mount" from util-linux, not busybox!).
Otherwise, I received a "VFS: Mount too revealing" from the kernel (Debian Trixie) when executing:
mount -t sysfs sysfs /sys
Afterwards, it is possible to unmount /sys_host and use all networking utilities.


Is there a particular reason why this feature had not been implemented?
Maybe there is a security implication that I did not recognize, or it is simply not the scope of the project.

Thank you for the creation and maintenance of bubblewrap.
It is a fine piece of software...!


Sincerely,
Alexander Schreiber (schreiberstein)