### PR TITLE
Reset SIGCHLD action to SIG_DFL

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2889,6 +2889,7 @@ main (int    argc,
   int intermediate_pids_sockets[2] = {-1, -1};
   const char *exec_path = NULL;
   int i;
+  struct sigaction sa = {};
 
   /* Handle --version early on before we try to acquire/drop
    * any capabilities so it works in a build environment;
@@ -2897,6 +2898,12 @@ main (int    argc,
    */
   if (argc == 2 && (strcmp (argv[1], "--version") == 0))
     print_version_and_exit ();
+
+  /* Reset SIGCHILD to SIG_DFL allowing signalfd working propertly
+   * if the parent process had set SIGCHLD to SIG_IGN. */
+  sigemptyset (&sa.sa_mask);
+  sa.sa_handler = SIG_DFL;
+  sigaction (SIGCHLD, &sa, NULL);
 
   real_uid = getuid ();
   real_gid = getgid ();


### PR DESCRIPTION
Some applications, like Erlang, call sigaction for SIGCHLD with `sa.sa_action = SIG_IGN`, this causes bwrap never read child process exit status from signalfd.

That behavior is explained in the function `do_notify_parent` at kernel/signal.c from linux kernel source, to be exact, in this section evaluates the signal action value:

https://github.com/torvalds/linux/blob/284922f4c563aa3a8558a00f2a05722133237fe8/kernel/signal.c#L2232-L2253

This fixes #705 