### PR TITLE
Enable user namespaces in Ubuntu CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,6 +17,8 @@ jobs:
       uses: actions/checkout@v4
     - name: Install build-dependencies
       run: sudo ./ci/builddeps.sh
+    - name: Enable user namespaces
+      run: sudo ./ci/enable-userns.sh
     - name: Create logs dir
       run: mkdir test-logs
     - name: setup

--- a/ci/enable-userns.sh
+++ b/ci/enable-userns.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+echo "kernel.apparmor_restrict_unprivileged_userns = 0" > /etc/sysctl.d/99-userns.conf
+sysctl --system


### PR DESCRIPTION
This change allows to run smoke-test again using the new (24.04) ubuntu-latest image