### PR TITLE
fix(bwrap): close pdeathsig parent race

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -383,8 +383,21 @@ usage (int ecode, FILE *out)
 static void
 handle_die_with_parent (void)
 {
-  if (opt_die_with_parent && prctl (PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0) != 0)
+  pid_t ppid;
+
+  if (!opt_die_with_parent)
+    return;
+
+  ppid = getppid ();
+  if (prctl (PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0) != 0)
     die_with_error ("prctl");
+
+  /* Close the race where our parent exits before PR_SET_PDEATHSIG takes effect. */
+  if (getppid () != ppid)
+    {
+      (void) kill (getpid (), SIGKILL);
+      _exit (1);
+    }
 }
 
 static void


### PR DESCRIPTION
At startup, the child process needs to die if the parent dies, so the child process sets PR_SET_PDEATHSIG so the kernel will SIGKILL it if the parent dies. Which is the whole setting up a parent-death signal with prctl. The problem is that if the parent dies after fork but before or during the prctl call, the child won't receive it because the parent is gone already so nothing will trigger it. So we end up with a VERY narrow window for failure after the fork/exec that can cause potential issues if the parent dies unexpectedly. The kill and _exit calls are there to handle the process safely if one of those windows is missed. I used _exit instead of exit so cleanup handlers don't run in post-forked code. It's a well known race and systemd and other projects use similar patterns to close it out.

As for the how it goes:
parent spawns child
child executes but hasn't called prctl(PR_SET_PDEATHSIG)
parent dies or exits
child then calls prctl(PR_SET_PDEATHSIG) but by now its too late

We grab ppid, set PDEATHSIG, then check later if getppid() isn't what what ppid() was before which means the parent is gone or swapped (like to PID 1 or something else) and this part is why it works at all. It's the reference point to compare against with later. It hardly ever happens, but it's documented and has a known a fix.