### PR TITLE
utils: use lstat() instead of stat() in ensure_file()

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -513,7 +513,7 @@ ensure_file (const char *path,
      We're trying to set up a mount point for a non-directory, so any
      non-directory, non-symlink is acceptable - it doesn't necessarily
      have to be a regular file. */
-  if (stat (path, &buf) ==  0 &&
+  if (lstat (path, &buf) ==  0 &&
       !S_ISDIR (buf.st_mode) &&
       !S_ISLNK (buf.st_mode))
     return 0;


### PR DESCRIPTION
Fixes #733.

`ensure_file()` checks `!S_ISLNK` to reject symlinks as bind-mount destinations, but uses `stat()` which follows symlinks. Since `stat()` resolves the symlink before returning, `S_ISLNK` is never true for valid symlinks, making the check dead code.

Use `lstat()` so the `S_ISLNK` check works as intended.