### PR TITLE
utils: Clarify that ensure_file, ensure_dir intentionally follow symlinks

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -510,14 +510,18 @@ ensure_file (const char *path,
      the create file will fail in the read-only
      case with EROFS instead of EEXIST.
 
-     We're trying to set up a mount point for a non-directory, so any
-     non-directory, non-symlink is acceptable - it doesn't necessarily
-     have to be a regular file. */
+     We're trying to set up a mount point for a non-directory, for which
+     the kernel will accept any non-directory. If it's a symlink, follow
+     it and look at the target: again, any non-directory is good enough.
+     We'll only get S_ISLNK if the path is a dangling symlink (target
+     doesn't exist). */
   if (stat (path, &buf) ==  0 &&
       !S_ISDIR (buf.st_mode) &&
       !S_ISLNK (buf.st_mode))
     return 0;
 
+  /* If the file didn't exist, create it. If it was a dangling symlink
+   * (S_ISLNK above) then this will create the target of the symlink. */
   if (create_file (path, mode, NULL) != 0 &&  errno != EEXIST)
     return -1;
 
@@ -681,7 +685,8 @@ ensure_dir (const char *path,
   /* We check this ahead of time, otherwise
      the mkdir call can fail in the read-only
      case with EROFS instead of EEXIST on some
-     filesystems (such as NFS) */
+     filesystems (such as NFS).
+     We follow symlinks: it's OK if path is a symlink to a directory. */
   if (stat (path, &buf) == 0)
     {
       if (!S_ISDIR (buf.st_mode))


### PR DESCRIPTION
In #733, the issue reporter thought that we'd intended to use lstat() in ensure_file(), because stat() doesn't normally result in S_ISLNK. In fact this was working as intended - we were checking for the one situation where stat() *will* produce S_ISLNK, which is a dangling symlink - but it wasn't as obvious as it could have been.

No functional change, comments only.

Fixes: https://github.com/containers/bubblewrap/issues/733

---

@dwahdany, if we had already had these comments, would that have avoided #733?