### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,13 +8,16 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   meson:
     name: Build with Meson and gcc, and test
     runs-on: ubuntu-latest
     steps:
     - name: Check out
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Install build-dependencies
       run: sudo ./ci/builddeps.sh
     - name: Enable user namespaces
@@ -71,7 +74,7 @@ jobs:
         test ! -e DESTDIR-as-subproject/usr/local/libexec/bwrap
         tests/use-as-subproject/assert-correct-rpath.py DESTDIR-as-subproject/usr/local/libexec/not-flatpak-bwrap
     - name: Upload test logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure() || cancelled()
       with:
         name: test logs
@@ -80,6 +83,8 @@ jobs:
   clang:
     name: Build with clang and analyze
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -87,11 +92,11 @@ jobs:
           - cpp
     steps:
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
     - name: Check out
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Install build-dependencies
       run: sudo ./ci/builddeps.sh --clang
     - run: meson build -Dselinux=enabled
@@ -102,4 +107,4 @@ jobs:
           -Werror=unused-variable
     - run: meson compile -C build
     - name: CodeQL analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
CodeQL Action v2 was discontinued last year:
https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated

Other deprecated Node.js 20 actions may not work after June 16th, 2026: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners

`security-events` permission is [required](https://github.com/github/codeql-action#workflow-permissions) by the CodeQL action