### PR TITLE
bubblewrap: Fix deadcode.DeadStores warnings from analyze-build

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -3089,9 +3089,6 @@ main (int    argc,
       die_with_error ("Creating new namespace failed");
     }
 
-  ns_uid = opt_sandbox_uid;
-  ns_gid = opt_sandbox_gid;
-
   if (pid != 0)
     {
       /* Parent, outside sandbox, privileged (initially) */


### PR DESCRIPTION
There were two duplicate assignment blocks without any intervening reads:

```c
ns_uid = opt_sandbox_uid;
ns_gid = opt_sandbox_gid;
...
ns_uid = opt_sandbox_uid;
ns_gid = opt_sandbox_gid;
```