### PR TITLE
bubblewrap: Fix leak of xasprintf-ed source path for --(ro)-bind-fd flag

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -158,6 +158,7 @@ struct _SetupOp
   SetupOpFlag flags;
   int         perms;
   size_t      size;  /* number of bytes, zero means unset/default */
+  bool        source_owned;
   SetupOp    *next;
 };
 
@@ -1375,6 +1376,13 @@ close_ops_fd (void)
           (void) close (op->fd);
           op->fd = -1;
         }
+
+      if (op->source_owned)
+        {
+          free ((char *) op->source);
+          op->source = NULL;
+          op->source_owned = false;
+        }
     }
 }
 
@@ -1407,6 +1415,11 @@ resolve_symlinks_in_ops (void)
               else
                 die_with_error("Can't find source path %s", old_source);
             }
+          else if (op->source_owned)
+            {
+              free ((char *) old_source);
+            }
+          op->source_owned = false;
           break;
 
         case SETUP_RO_OVERLAY_MOUNT:
@@ -1734,6 +1747,7 @@ parse_args_recurse (int          *argcp,
           else
             op = setup_op_new (SETUP_BIND_MOUNT);
           op->source = xasprintf ("/proc/self/fd/%d", src_fd);
+          op->source_owned = true;
           op->fd = src_fd;
           op->dest = argv[2];
 


### PR DESCRIPTION
When --bind-fd or --ro-bind-fd is used, op->source is set to a heap-allocated string from xasprintf() which was not being free-d

The trace is from 0.11.0

```
Direct leak of 34 byte(s) in 2 object(s) allocated from:
    #0 0x7fb8df6fd9c7  (/lib/x86_64-linux-gnu/libasan.so.8+0xfd9c7) (BuildId: 0241d5a774aeb1d6babd9f68d743bdcf31b4a97d)
    #1 0x7fb8dea8f947  (/lib/x86_64-linux-gnu/libc.so.6+0x8f947) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
    #2 0x7fb8df6cf32e  (/lib/x86_64-linux-gnu/libasan.so.8+0xcf32e) (BuildId: 0241d5a774aeb1d6babd9f68d743bdcf31b4a97d)
    #3 0x55f2646fdddd in xasprintf ../subprojects/bubblewrap/utils.c:364
    #4 0x55f2646e73e7 in parse_args_recurse ../subprojects/bubblewrap/bubblewrap.c:2018
    #5 0x55f2646e5867 in parse_args_recurse ../subprojects/bubblewrap/bubblewrap.c:1855
    #6 0x55f2646efc76 in parse_args ../subprojects/bubblewrap/bubblewrap.c:2782
    #7 0x55f2646f10e8 in main ../subprojects/bubblewrap/bubblewrap.c:2927
    #8 0x7fb8dea2a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
    #9 0x7fb8dea2a28a  (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
    #10 0x55f2646d7344 in _start (/home/runner/work/flatpak/flatpak/builddir/subprojects/bubblewrap/flatpak-bwrap+0x3b344) (BuildId: c4d1276e28ed30dbeb13c58c7bd96078e062ef26)
SUMMARY: AddressSanitizer: 34 byte(s) leaked in 2 allocation(s).
```