### PR TITLE
bubblewrap: Allow operation as a `setgid` binary

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -785,8 +785,10 @@ static void
 acquire_privs (void)
 {
   uid_t euid;
+  gid_t egid;
 
   euid = geteuid ();
+  egid = getegid ();
 
   /* Are we setuid ? */
   if (real_uid != euid)
@@ -815,6 +817,21 @@ acquire_privs (void)
 
       requested_caps[0] = data[0].effective;
       requested_caps[1] = data[1].effective;
+    }
+
+  if (real_gid != egid)
+    {
+      /* We are running as a setgid binary. This allows us to acquire the
+        permissions of the group without privileged operations, and we can
+        preserve those inside the unprivileged user namespace. We need to
+        make sure that real and effective gid match though. */
+      if (setresgid (egid, egid, egid) < 0)
+        die_with_error ("Unable to set real gid from effective gid");
+      real_gid = egid;
+
+      /* Privileges are consistent now, mark dumpable to allow access to /proc/self */
+      if (prctl (PR_SET_DUMPABLE, 1, 0, 0, 0) != 0)
+        die_with_error ("can't set dumpable after setgid");
     }
 
   /* Else, we try unprivileged user namespaces */


### PR DESCRIPTION
Use case: as an unprivileged user with a group membership, I can access files (devices) with group access, e.g. a GPU:

```
$ id -a
uid=1000(developer) gid=1000(developer) groups=1000(developer),<...>,44(video),<...>
$ ls -l /dev/nvhost-*
crw-rw---- 1 root video 506,  1 Jun 17 13:40 /dev/nvhost-as-gpu
crw-rw---- 1 root video 242,  0 Jun 17 13:40 /dev/nvhost-ctrl
crw-rw---- 1 root video 506,  2 Jun 17 13:40 /dev/nvhost-ctrl-gpu
<...>

```

To access the video device from a `bwrap` sandbox, I need to map the `video` group in the user namespace, which is possible by making it my real and effective group id:

```
sudo -g video bwrap --unshare-all <...>
```

However, this means there is a `setuid` binary in the process tree, and the parent process can't easily manage the child. Using the `setgid` flag, we can achieve the same effect without any privileged/setuid-root operations, and use any supplementary group as an effective group:

```
cp $(which bwrap) bwrap
chown :video bwrap
chmod g+s bwrap
./bwrap --unshare-all <...>
```

This fixes an issue in this setup where `bwrap` would fail to setup the uid mapping in this scenario.

I am not sure in exactly which scenarios this is required, it appears that I can access normal files owned by any supplementary group even if the group is not mapped. But is certainly helpful to be able to create files owned by a specific group, and it appears to be required to access the video hardware on this platform and kernel (which certainly also has bugs in its user namespace implementation).