### PR TITLE
bubblewrap: reopen proc_fd from inside namespace

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -3151,6 +3151,13 @@ main (int    argc,
       return monitor_child (event_fd, pid, setup_finished_pipe[0]);
     }
 
+  /* Reopen the /proc file descriptor from inside the namespace to avoid
+   * AppArmor complaining about the path being disconnected. */
+  close (proc_fd);
+  proc_fd = TEMP_FAILURE_RETRY (open ("/proc", O_PATH));
+  if (proc_fd == -1)
+    die_with_error ("Can't open /proc");
+
   if (opt_pidns_fd != -1)
     {
       if (setns (opt_pidns_fd, CLONE_NEWPID) != 0)


### PR DESCRIPTION
AppArmor in complain or enforce mode will not allow the use of fds that are "disconnected" from the namespace root. Disconnected as far as I understand means that its from a separate mount namespace and it won't be able to reconstruct  a full path string to match against rules.

* https://apparmor.net/about/faq/#failed-name-lookup-disconnected-path
* https://gitlab.com/apparmor/apparmor/-/blob/d1d120e781e1c990fc23edb3e73da965ac0d4ff0/parser/techdoc.tex#L203-223
* https://gitlab.com/apparmor/apparmor/-/work_items/363

This results in apparmor disallowing `openat` calls wit h `EACCESS`:
```
$ aa-exec -p flatpak bwrap --ro-bind / / id   
bwrap: setting up uid map: Permission denied
```

```
AVC apparmor="ALLOWED" operation="open" class="file" info="Failed name lookup - disconnected path" error=-13 profile="flatpak//null-/usr/bin/bwrap" name="proc/3483250/uid_map" pid=3483250 comm="bwrap" requested_mask="wr" denied_mask="wr" fsuid=1000 ouid=1000
```

```
[3518338] openat(AT_FDCWD, "/proc", O_RDONLY|O_PATH) = 3
...
[3518338] clone(child_stack=NULL, flags=CLONE_NEWNS|CLONE_NEWUSER|SIGCHLD) = 3518339
...
[3518339] openat(3, "self", O_RDONLY|O_PATH)      = 4
[3518339] openat(4, "uid_map", O_RDWR|O_CLOEXEC)  = -1 EACCES (Permission denied)
```