### PR TITLE
Preserve nosymfollow across bind-mount flag fixups

### DIFF
--- a/bind-mount.c
+++ b/bind-mount.c
@@ -24,6 +24,11 @@
 #include "utils.h"
 #include "bind-mount.h"
 
+/* MS_NOSYMFOLLOW was added in Linux 5.10 */
+#ifndef MS_NOSYMFOLLOW
+#define MS_NOSYMFOLLOW 256
+#endif
+
 static char *
 skip_token (char *line, bool eat_whitespace)
 {
@@ -93,6 +98,7 @@ decode_mountoptions (const char *options)
     { MS_NOSUID, "nosuid" },
     { MS_NODEV, "nodev" },
     { MS_NOEXEC, "noexec" },
+    { MS_NOSYMFOLLOW, "nosymfollow" },
     { MS_NOATIME, "noatime" },
     { MS_NODIRATIME, "nodiratime" },
     { MS_RELATIME, "relatime" },

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -91,6 +91,12 @@ else
 fi
 ok "--symlink doesn't overwrite a conflicting symlink"
 
+# A nosymfollow source must stay nosymfollow across the fixup remount
+if unshare -rm sh -c 'mount -t tmpfs -o nosymfollow tmpfs /tmp && : >/tmp/x && ln -s x /tmp/l && '"$BWRAP"' --ro-bind / / cat /tmp/l' 2>/dev/null; then
+    assert_not_reached "nosymfollow dropped by bind fixup; symlink was followed"
+fi
+ok "bind mount preserves nosymfollow"
+
 # Test devices
 $RUN --unshare-pid --dev /dev ls -al /dev/{stdin,stdout,stderr,null,random,urandom,fd,core} >/dev/null
 ok "all expected devices were created"


### PR DESCRIPTION
When bubblewrap binds a host mount that was mounted `nosymfollow` (for example systemd credential mounts), the flag is silently cleared inside the sandbox whenever the bind triggers bubblewrap's flag-fixup remount.

Example:
```sh
unshare -rm sh -c '
  mkdir -p /mnt/nsf
  mount -t tmpfs -o nosymfollow tmpfs /mnt/nsf
  printf secret > /mnt/nsf/x
  ln -s x /mnt/nsf/l
  cat /mnt/nsf/l                       # host:    Too many levels of symbolic links
  bwrap --ro-bind / / cat /mnt/nsf/l   # sandbox: prints "secret"
'
```

Expected: the sandbox refuses to follow the symlink (`ELOOP`), just like the host.
Actual: the sandbox prints `secret`, as `nosymfollow` was dropped.

This happens because `decode_mountoptions` parses the mount's flags from `/proc/self/mountinfo` through a table that has no `nosymfollow` entry. The fixup remount then passes only the decoded flags and `nosymfollow` is cleared. The fix is to add the table entry. A test entry for the case is also added to test-run.sh for good measure.