### PR TITLE
safe_openat: Use GNU __typeof__ rather than ISO C23 typeof

### DIFF
--- a/safe_openat.c
+++ b/safe_openat.c
@@ -89,7 +89,7 @@ syscall_openat2 (int dirfd, const char *path, uint64_t flags, uint64_t mode, uin
 
 #define consume_slashes(t) \
   ({                       \
-    typeof (t) _s = (t);   \
+    __typeof__ (t) _s = (t);   \
     while (*_s == '/')     \
       _s++;                \
     _s;                    \


### PR DESCRIPTION
When compiling with a specific ISO C functionality level like `-std=c99` or an older version of gcc, the C23 typeof keyword isn't recognised.

---

Follow-up after the security fixes in 0.12.0.

This is probably not needed on any modern distro/compiler (I tried on Ubuntu LTS back to 20.04 and they were all fine with `typeof()`), but for historical reasons the Steam Runtime does need this.