### PR TITLE
mount_setattr followups

### DIFF
--- a/bind-mount.c
+++ b/bind-mount.c
@@ -38,6 +38,7 @@ mount_setattr_fallback(char *resolved_dest, bind_option_t options, char **failin
 
 bool opt_force_mount_setattr_fallback = false;
 
+#if USE_MOUNT_SETATTR_FALLBACK
 static char *
 skip_token (char *line, bool eat_whitespace)
 {
@@ -386,6 +387,7 @@ parse_mountinfo (const char *root_mount)
 
   return steal_pointer (&mount_tab);
 }
+#endif /* USE_MOUNT_SETATTR_FALLBACK */
 
 bind_mount_result
 bind_mount (const char   *src,

--- a/bind-mount.c
+++ b/bind-mount.c
@@ -662,45 +662,45 @@ mount_setattr_setup(char *resolved_dest, bind_option_t options, char **failing_p
   bool recursive = (options & BIND_RECURSIVE) != 0;
 
   if (mount_attr_supported && !opt_force_mount_setattr_fallback)
-  {
-    struct mount_attr attr = {
-      .attr_clr = 0,
-      .attr_set = MOUNT_ATTR_NOSUID,
-    };
-
-    if (!devices)
-      attr.attr_set |= MOUNT_ATTR_NODEV;
-
-    if (readonly)
-      attr.attr_set |= MOUNT_ATTR_RDONLY;
-
-    unsigned int setattr_flags = AT_EMPTY_PATH;
-
-    if (recursive)
-      setattr_flags |= AT_RECURSIVE;
-
-    /* reopen dest_fd after mount() */
-    cleanup_fd int resolved_dest_fd =
-      TEMP_FAILURE_RETRY(open(resolved_dest, O_PATH | O_CLOEXEC));
-    if (resolved_dest_fd < 0)
-      {
-        if (failing_path != NULL)
-          *failing_path = steal_pointer (&resolved_dest);
-
-        return BIND_MOUNT_ERROR_OPEN_FD;
-      }
-    if (mount_setattr_wrapper (resolved_dest_fd, "", setattr_flags, &attr, sizeof(attr)) == 0)
     {
-      return BIND_MOUNT_SUCCESS;
+      struct mount_attr attr = {
+        .attr_clr = 0,
+        .attr_set = MOUNT_ATTR_NOSUID,
+      };
+
+      if (!devices)
+        attr.attr_set |= MOUNT_ATTR_NODEV;
+
+      if (readonly)
+        attr.attr_set |= MOUNT_ATTR_RDONLY;
+
+      unsigned int setattr_flags = AT_EMPTY_PATH;
+
+      if (recursive)
+        setattr_flags |= AT_RECURSIVE;
+
+      /* reopen dest_fd after mount() */
+      cleanup_fd int resolved_dest_fd =
+        TEMP_FAILURE_RETRY(open(resolved_dest, O_PATH | O_CLOEXEC));
+      if (resolved_dest_fd < 0)
+        {
+          if (failing_path != NULL)
+            *failing_path = steal_pointer (&resolved_dest);
+
+          return BIND_MOUNT_ERROR_OPEN_FD;
+        }
+      if (mount_setattr_wrapper (resolved_dest_fd, "", setattr_flags, &attr, sizeof(attr)) == 0)
+        {
+          return BIND_MOUNT_SUCCESS;
+        }
+      else if (errno != ENOSYS)
+        {
+          if (failing_path != NULL)
+            *failing_path = steal_pointer (&resolved_dest);
+          mount_attr_supported = false;
+          return BIND_MOUNT_ERROR_MOUNT_SETATTR;
+        }
     }
-    else if (errno != ENOSYS)
-    {
-      if (failing_path != NULL)
-        *failing_path = steal_pointer (&resolved_dest);
-      mount_attr_supported = false;
-      return BIND_MOUNT_ERROR_MOUNT_SETATTR;
-    }
-  }
   /* mount_setattr(2) isn't available, so we'll have to do this the hard way: */
   return mount_setattr_fallback (resolved_dest, options, failing_path);
 }

--- a/bind-mount.c
+++ b/bind-mount.c
@@ -30,11 +30,13 @@
 #  define USE_MOUNT_SETATTR_FALLBACK 0
 #endif
 
-static bind_mount_result
-mount_setattr_setup(char *resolved_dest, bind_option_t options, char **failing_path);
+static bind_mount_result mount_setattr_setup (const char *resolved_dest,
+                                              bind_option_t options,
+                                              char **failing_path);
 
-static bind_mount_result
-mount_setattr_fallback(char *resolved_dest, bind_option_t options, char **failing_path);
+static bind_mount_result mount_setattr_fallback (const char *resolved_dest,
+                                                 bind_option_t options,
+                                                 char **failing_path);
 
 bool opt_force_mount_setattr_fallback = false;
 
@@ -466,7 +468,9 @@ bind_mount_fd (int           src_fd,
 }
 
 static bind_mount_result
-mount_setattr_fallback(char *resolved_dest, bind_option_t options, char **failing_path)
+mount_setattr_fallback (const char *resolved_dest,
+                        bind_option_t options,
+                        char **failing_path)
 {
 #if !USE_MOUNT_SETATTR_FALLBACK
   (void) resolved_dest;
@@ -486,7 +490,7 @@ mount_setattr_fallback(char *resolved_dest, bind_option_t options, char **failin
   if (mount_tab[0].mountpoint == NULL)
     {
       if (failing_path != NULL)
-        *failing_path = steal_pointer (&resolved_dest);
+        *failing_path = xstrdup (resolved_dest);
 
       errno = EINVAL;
       return BIND_MOUNT_ERROR_FIND_DEST_MOUNT;
@@ -500,7 +504,7 @@ mount_setattr_fallback(char *resolved_dest, bind_option_t options, char **failin
              NULL, MS_SILENT | MS_BIND | MS_REMOUNT | new_flags, NULL) != 0)
     {
       if (failing_path != NULL)
-        *failing_path = steal_pointer (&resolved_dest);
+        *failing_path = xstrdup (resolved_dest);
 
       return BIND_MOUNT_ERROR_REMOUNT_DEST;
     }
@@ -656,7 +660,9 @@ die_with_bind_result (bind_mount_result res,
 }
 
 static bind_mount_result
-mount_setattr_setup(char *resolved_dest, bind_option_t options, char **failing_path)
+mount_setattr_setup (const char *resolved_dest,
+                     bind_option_t options,
+                     char **failing_path)
 {
   static bool mount_attr_supported = true;
   bool readonly = (options & BIND_READONLY) != 0;
@@ -687,10 +693,11 @@ mount_setattr_setup(char *resolved_dest, bind_option_t options, char **failing_p
       if (resolved_dest_fd < 0)
         {
           if (failing_path != NULL)
-            *failing_path = steal_pointer (&resolved_dest);
+            *failing_path = xstrdup (resolved_dest);
 
           return BIND_MOUNT_ERROR_OPEN_FD;
         }
+
       if (mount_setattr_wrapper (resolved_dest_fd, "", setattr_flags, &attr, sizeof(attr)) == 0)
         {
           return BIND_MOUNT_SUCCESS;
@@ -698,7 +705,7 @@ mount_setattr_setup(char *resolved_dest, bind_option_t options, char **failing_p
       else if (errno != ENOSYS)
         {
           if (failing_path != NULL)
-            *failing_path = steal_pointer (&resolved_dest);
+            *failing_path = xstrdup (resolved_dest);
           mount_attr_supported = false;
           return BIND_MOUNT_ERROR_MOUNT_SETATTR;
         }

--- a/bind-mount.c
+++ b/bind-mount.c
@@ -709,10 +709,10 @@ mount_setattr_setup (const char *resolved_dest,
         {
           if (failing_path != NULL)
             *failing_path = xstrdup (resolved_dest);
-          mount_attr_supported = false;
           return BIND_MOUNT_ERROR_MOUNT_SETATTR;
         }
     }
   /* mount_setattr(2) isn't available, so we'll have to do this the hard way: */
+  mount_attr_supported = false;
   return mount_setattr_fallback (resolved_dest, options, failing_path);
 }

--- a/bind-mount.c
+++ b/bind-mount.c
@@ -475,7 +475,10 @@ mount_setattr_fallback (const char *resolved_dest,
 #if !USE_MOUNT_SETATTR_FALLBACK
   (void) resolved_dest;
   (void) options;
-  (void) failing_path;
+
+  if (failing_path != NULL)
+    *failing_path = xstrdup (resolved_dest);
+
   errno = ENOSYS;
   return BIND_MOUNT_ERROR_MOUNT_SETATTR;
 #else

--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -2719,12 +2719,31 @@ parse_args_recurse (int          *argcp,
       else if (has_prefix (arg, "--debug-opt="))
         {
           const char *val = arg + strlen ("--debug-opt=");
+
           if (strcmp (val, "force-openat-fallback") == 0)
-            opt_force_openat_fallback = true;
+            {
+              opt_force_openat_fallback = true;
+            }
           else if (strcmp (val, "force-mount-setattr-fallback") == 0)
-            opt_force_mount_setattr_fallback = true;
+            {
+              opt_force_mount_setattr_fallback = true;
+            }
+          else if (strcmp (val, "print-assumed-kernel") == 0)
+            {
+#ifdef HAVE_ASSUMED_KERNEL
+              printf ("%u.%u.%u\n",
+                      ASSUMED_KERNEL_MAJOR,
+                      ASSUMED_KERNEL_MINOR,
+                      ASSUMED_KERNEL_PATCH);
+#else
+              printf ("0.0.0\n");
+#endif
+              exit (0);
+            }
           else
-            die ("Unknown --debug-opt value: %s", val);
+            {
+              die ("Unknown --debug-opt value: %s", val);
+            }
         }
       else if (strcmp (arg, "--") == 0)
         {

--- a/tests/test-helper.py
+++ b/tests/test-helper.py
@@ -225,6 +225,18 @@ def can_run_bwrap():
         return False
 
 
+def get_assumed_kernel():
+    """Return the minimum kernel supported by BWRAP, e.g. 5.10.0"""
+    r = subprocess.run(
+        [BWRAP, '--debug-opt=print-assumed-kernel'],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+    return tuple([int(n) for n in r.stdout.decode('ascii').strip().split('.')])
+
+
 class TAPResult(unittest.TestResult):
     def __init__(self):
         super().__init__()

--- a/tests/test-sandbox.py
+++ b/tests/test-sandbox.py
@@ -26,6 +26,7 @@ _spec.loader.exec_module(_helper)
 
 BWRAP = _helper.BWRAP
 can_run_bwrap = _helper.can_run_bwrap
+get_assumed_kernel = _helper.get_assumed_kernel
 in_sandbox = _helper.in_sandbox
 list_mounts = _helper.list_mounts
 DataFd = _helper.DataFd
@@ -311,8 +312,14 @@ class TestSandbox(unittest.TestCase):
         self._test_ro_bind_root_is_recursive()
 
     @in_sandbox('--debug-opt=force-mount-setattr-fallback')
-    def test_ro_bind_root_is_recursive_fallback(self):
+    def _test_ro_bind_root_is_recursive_fallback(self):
         self._test_ro_bind_root_is_recursive()
+
+    def test_ro_bind_root_is_recursive_fallback(self):
+        if get_assumed_kernel() >= (5, 12, 0):
+            self.skipTest('mount_setattr() fallback not compiled')
+        else:
+            self._test_ro_bind_root_is_recursive_fallback()
 
     def _test_ro_bind_root_is_recursive(self):
         """The base --ro-bind / / should apply read-only to sub-mounts."""


### PR DESCRIPTION
cc @xxyzz @alexlarsson 

* bind-mount: Use conventional indentation
    
    No functional change, `git show --ignore-space-change` shows nothing.

* bind-mount: Don't compile mountinfo parser if unused
    
    If we're assuming a sufficiently recent kernel, this is dead code because
    we'll rely on mount_setattr().

* bind-mount: Fix use-after-free of resolved_dest on remount errors
    
    resolved_dest is a malloc'd string, owned by bind_mount_fd().
    If we output it through the failing_path "out" parameter,
    then bind_mount_fd() will automatically free it, leaving the caller with
    a dangling pointer which they'll probably try to print (causing a
    use-after-free) and/or free (causing a double-free).
    
    Previously, the use of steal_pointer() prevented this because
    bind_mount_fd() was one big function, but that doesn't work when
    crossing function boundaries and passing the pointer as an argument.
    We could make mount_setattr_setup() and mount_setattr_fallback
    "steal" ownership of the resolved_dest argument, but those would be
    unusual and confusing semantics, so it seems less error-prone to make
    the argument const and copy the string if an error occurs.

* bind-mount: Set failing path when mount_setattr fallback is compiled out
    
    The calling convention for bind_mount_fd(), mount_setattr_setup()
    and mount_setattr_fallback() is that if they return
    BIND_MOUNT_ERROR_MOUNT_SETATTR, then the failing_path is expected
    to be set.

* Add a --debug-opt to show what minimum kernel we are assuming

* Don't test --debug-opt=force-mount-setattr-fallback if unsupported
    
    If we're assuming a sufficiently new kernel, we won't fall back
    if mount_setattr() fails.

* bind-mount: Don't unset mount_attr_supported on errors other than ENOSYS
    
    If mount_setattr() fails for some reason other than ENOSYS, for example
    EPERM or EBUSY, then we want to report that error rather than falling
    back to the old implementation (if allowed by assume_kernel) or
    overwriting the error with ENOSYS (otherwise).
    
    Thanks: xxyzz