### PR TITLE
Add limits.h include for PATH_MAX

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -21,6 +21,7 @@
 
 #include <poll.h>
 #include <sched.h>
+#include <limits.h>
 #include <pwd.h>
 #include <grp.h>
 #include <ctype.h>

--- a/safe_openat.c
+++ b/safe_openat.c
@@ -21,6 +21,7 @@
 
 #include "utils.h"
 #include <sys/syscall.h>
+#include <limits.h>
 #include <unistd.h>
 #include <errno.h>
 #include <stdint.h>


### PR DESCRIPTION
This is required for musl libc, where limits.h is not implicitly included by the other includes.