### PR TITLE
Build on older systems

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -903,6 +903,8 @@ pivot_root (const char * new_root, const char * put_old)
 #ifdef __NR_pivot_root
   return syscall (__NR_pivot_root, new_root, put_old);
 #else
+  (void) new_root;
+  (void) put_old;
   errno = ENOSYS;
   return -1;
 #endif
@@ -1104,6 +1106,11 @@ mount_setattr_wrapper (int dirfd, const char *path, unsigned int flags,
 #ifdef __NR_mount_setattr
   return syscall (__NR_mount_setattr, dirfd, path, flags, attr, size);
 #else
+  (void) dirfd;
+  (void) path;
+  (void) flags;
+  (void) attr;
+  (void) size;
   errno = ENOSYS;
   return -1;
 #endif

--- a/utils.h
+++ b/utils.h
@@ -255,7 +255,9 @@ fdset_add (FdSet *set, int fd)
 static inline void
 cleanup_fdsetp (FdSet *set)
 {
-  for (size_t i = 0; i < set->len; i++)
+  size_t i;
+
+  for (i = 0; i < set->len; i++)
     if (set->fds[i] >= 0)
       close (set->fds[i]);
   free (set->fds);

--- a/utils.h
+++ b/utils.h
@@ -289,6 +289,9 @@ void strappend_escape_for_mount_options (StringBuilder *dest,
                                          const char    *src);
 
 #ifndef MOUNT_ATTR_RDONLY
+
+#include <linux/types.h>
+
 struct mount_attr
 {
   __u64 attr_set;


### PR DESCRIPTION
Fix building bubblewrap on some older systems, like for example the SDK from https://gitlab.steamos.cloud/steamrt/scout/sdk

cc @smcv 