### PR TITLE
utils: hard-require `pivot_root`

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -28,6 +28,10 @@
 #include <selinux/selinux.h>
 #endif
 
+#ifndef __NR_pivot_root
+#error Linux kernel headers with __NR_pivot_root are required
+#endif
+
 #ifndef HAVE_SELINUX_2_3
 /* libselinux older than 2.3 weren't const-correct */
 #define setexeccon(x) setexeccon ((security_context_t) x)
@@ -900,14 +904,7 @@ raw_clone (unsigned long flags,
 int
 pivot_root (const char * new_root, const char * put_old)
 {
-#ifdef __NR_pivot_root
   return syscall (__NR_pivot_root, new_root, put_old);
-#else
-  (void) new_root;
-  (void) put_old;
-  errno = ENOSYS;
-  return -1;
-#endif
 }
 
 char *


### PR DESCRIPTION
`pivot_root` is a Linux 2.3.41 feature, and is available in the Linux 3.2 headers from Ubuntu 12.04, which is probably the oldest environment in which anyone might reasonably want to compile bwrap.

So hard-require `pivot_root` when building bubblewrap and remove the fallback path.

cc @smcv 